### PR TITLE
Apply rotation before translation for collision shapes; simplify number input config

### DIFF
--- a/common/src/main/java/com/fangsu/blockEntities/BlockEntityTicketBarrier.java
+++ b/common/src/main/java/com/fangsu/blockEntities/BlockEntityTicketBarrier.java
@@ -392,13 +392,13 @@ public class BlockEntityTicketBarrier extends BaseObjBlockEntity {
         float rotY = this.rotateY + (float) Math.toRadians(-facing.toYRot());
         float rotZ = this.rotateZ;
         long posLong = worldPosition.asLong();
-        shape.translate(trans);
         VoxelShape openShape = CollisionBoxUtil.cachedRotatedShape(posLong, shape, Vec3.ZERO, rotX, rotY, rotZ, 0.1f);
+        openShape = openShape.move(trans.x, trans.y, trans.z);
         if (isOpen || doorCloseShape == null) {
             return openShape;
         }
-        doorCloseShape.translate(trans);
         VoxelShape closeShape = CollisionBoxUtil.cachedRotatedShape(posLong, doorCloseShape, Vec3.ZERO, rotX, rotY, rotZ, 0.1f);
+        closeShape = closeShape.move(trans.x, trans.y, trans.z);
         return Shapes.or(openShape, closeShape);
     }
 
@@ -412,13 +412,13 @@ public class BlockEntityTicketBarrier extends BaseObjBlockEntity {
         float rotY = this.rotateY + (float) Math.toRadians(-facing.toYRot());
         float rotZ = this.rotateZ;
         long posLong = worldPosition.asLong();
-        baseCollision.translate(trans);
         VoxelShape openShape = CollisionBoxUtil.cachedRotatedShape(posLong, baseCollision, Vec3.ZERO, rotX, rotY, rotZ, 1);
+        openShape = openShape.move(trans.x, trans.y, trans.z);
         if (isOpen || closeCollision == null) {
             return openShape;
         }
-        closeCollision.translate(trans);
         VoxelShape closeShape = CollisionBoxUtil.cachedRotatedShape(posLong, closeCollision, Vec3.ZERO, rotX, rotY, rotZ, 1);
+        closeShape = closeShape.move(trans.x, trans.y, trans.z);
         return Shapes.or(openShape, closeShape);
     }
 

--- a/common/src/main/java/com/fangsu/extraConfig/BoolConfig.java
+++ b/common/src/main/java/com/fangsu/extraConfig/BoolConfig.java
@@ -25,10 +25,11 @@ public class BoolConfig extends ConfigEntry<Boolean> {
                 b -> {
                     value = !value;
                     b.setMessage(label());
+                    notifyValueChanged();
                 }
         ).bounds(x + labelW, y, fieldW, 20).build();
 
-        return new ConfigWidget(x, y, labelW + fieldW, 20, title, btn);
+        return new ConfigWidget(x, y, labelW + fieldW, 20, labelW, title, btn);
     }
 
     private Component label() {

--- a/common/src/main/java/com/fangsu/extraConfig/ConfigEntry.java
+++ b/common/src/main/java/com/fangsu/extraConfig/ConfigEntry.java
@@ -19,6 +19,8 @@ public abstract class ConfigEntry<T> {
     protected T value;
 
     protected Function<T, Boolean> showCondition;
+    private boolean saveOnChange = false;
+    private Consumer<ConfigEntry<?>> changeListener;
 
     protected ConfigEntry(
             Component title,
@@ -35,6 +37,25 @@ public abstract class ConfigEntry<T> {
     public ConfigEntry<T> setShowCondition(Function<T, Boolean> showCondition) {
         this.showCondition = showCondition;
         return this;
+    }
+
+    public ConfigEntry<T> setSaveOnChange(boolean saveOnChange) {
+        this.saveOnChange = saveOnChange;
+        return this;
+    }
+
+    public boolean isSaveOnChange() {
+        return saveOnChange;
+    }
+
+    public void setChangeListener(Consumer<ConfigEntry<?>> changeListener) {
+        this.changeListener = changeListener;
+    }
+
+    protected void notifyValueChanged() {
+        if (changeListener != null) {
+            changeListener.accept(this);
+        }
     }
 
 //    public abstract ConfigEntry<?> fromJson(JsonObject json,

--- a/common/src/main/java/com/fangsu/extraConfig/ConfigWidget.java
+++ b/common/src/main/java/com/fangsu/extraConfig/ConfigWidget.java
@@ -14,16 +14,19 @@ import java.util.List;
 public class ConfigWidget extends AbstractWidget {
 
     private final List<AbstractWidget> children = new ArrayList<>();
+    private final int labelWidth;
 
     public ConfigWidget(
             int x,
             int y,
             int width,
             int height,
+            int labelWidth,
             Component title,
             AbstractWidget... widgets
     ) {
         super(x, y, width, height, title);
+        this.labelWidth = labelWidth;
         for (AbstractWidget w : widgets) {
             this.children.add(w);
         }
@@ -85,6 +88,20 @@ public class ConfigWidget extends AbstractWidget {
 
     @Override
     protected void renderWidget(GuiGraphics gui, int mouseX, int mouseY, float partialTick) {
+        var font = net.minecraft.client.Minecraft.getInstance().font;
+        int maxWidth = Math.max(0, labelWidth - 4);
+        String label = maxWidth > 0
+                ? font.plainSubstrByWidth(getMessage().getString(), maxWidth)
+                : getMessage().getString();
+        int textY = getY() + (height - 8) / 2;
+        gui.drawString(
+                font,
+                label,
+                getX(),
+                textY,
+                0x202020,
+                false
+        );
         for (AbstractWidget w : children) {
             w.render(gui, mouseX, mouseY, partialTick);
         }

--- a/common/src/main/java/com/fangsu/extraConfig/EnumConfig.java
+++ b/common/src/main/java/com/fangsu/extraConfig/EnumConfig.java
@@ -30,6 +30,7 @@ public class EnumConfig extends ConfigEntry<Integer> {
                 b -> {
                     value = (value + 1) % entries.size();
                     b.setMessage(entries.get(value));
+                    notifyValueChanged();
                 }
         ).bounds(x + labelW, y, fieldW, 20).build();
 
@@ -37,6 +38,7 @@ public class EnumConfig extends ConfigEntry<Integer> {
                 x, y,
                 labelW + fieldW,
                 20,
+                labelW,
                 title,
                 btn
         );

--- a/common/src/main/java/com/fangsu/extraConfig/MultiLineTextWidget.java
+++ b/common/src/main/java/com/fangsu/extraConfig/MultiLineTextWidget.java
@@ -11,7 +11,8 @@ public class MultiLineTextWidget extends MultiLineEditBox {
 
     public MultiLineTextWidget(
             int x, int y, int w, int h,
-            String initial
+            String initial,
+            java.util.function.Consumer<String> onChanged
     ) {
         super(
                 Minecraft.getInstance().font,
@@ -20,6 +21,9 @@ public class MultiLineTextWidget extends MultiLineEditBox {
                 Component.empty()
         );
         this.setValue(initial);
+        if (onChanged != null) {
+            this.setValueListener(onChanged);
+        }
     }
 
     /** UI 关闭时由 ConfigEntry 主动读取 */

--- a/common/src/main/java/com/fangsu/extraConfig/NumberConfig.java
+++ b/common/src/main/java/com/fangsu/extraConfig/NumberConfig.java
@@ -47,7 +47,10 @@ public class NumberConfig extends ConfigEntry<Float> {
                 min,
                 max,
                 step,
-                v -> value = v
+                v -> {
+                    value = v;
+                    notifyValueChanged();
+                }
         );
 
         /* ---------- Input ---------- */
@@ -66,6 +69,7 @@ public class NumberConfig extends ConfigEntry<Float> {
                 float v = Float.parseFloat(str);
                 value = v;
                 slider.setExternal(v);
+                notifyValueChanged();
             } catch (NumberFormatException ignored) {
             }
         });
@@ -93,6 +97,7 @@ public class NumberConfig extends ConfigEntry<Float> {
                 y,
                 labelW + fieldW,
                 20,
+                labelW,
                 title,
                 new CompoundWidget(slider, input, toggle)
         );

--- a/common/src/main/java/com/fangsu/extraConfig/NumberInputConfig.java
+++ b/common/src/main/java/com/fangsu/extraConfig/NumberInputConfig.java
@@ -16,9 +16,6 @@ public class NumberInputConfig extends ConfigEntry<Float> {
     private final float max;
     private final boolean isInt;
 
-    // 在 createWidget 中创建并保存引用，以便 save() 时读取最新文本
-    private EditBox inputBox;
-
     public NumberInputConfig(
             Component title,
             ConfigSpec spec,
@@ -37,7 +34,7 @@ public class NumberInputConfig extends ConfigEntry<Float> {
         int fieldX = x + labelW;
 
         // 创建 EditBox，初始值使用当前 value（load() 后 value 已经被设置）
-        inputBox = new EditBox(
+        EditBox inputBox = new EditBox(
                 Minecraft.getInstance().font,
                 fieldX,
                 y,
@@ -64,13 +61,14 @@ public class NumberInputConfig extends ConfigEntry<Float> {
                     float fv = Float.parseFloat(text.trim());
                     value = clamp(fv);
                 }
+                notifyValueChanged();
             } catch (NumberFormatException ignored) {
                 // 不合法输入时，不改变 value（等用户修正）
             }
         });
 
         // 初始可见 / 可用性由 ConfigEntry.isVisible() 决定
-        return new ConfigWidget(x, y, labelW + fieldW, height, title, inputBox);
+        return new ConfigWidget(x, y, labelW + fieldW, height, labelW, title, inputBox);
     }
 
     @Override
@@ -92,29 +90,6 @@ public class NumberInputConfig extends ConfigEntry<Float> {
             float def = spec.getFloat("default", Float.NaN);
             if (!Float.isNaN(def)) value = def;
         }
-    }
-
-    @Override
-    public void save(Object be) {
-        // 当 UI 关闭时由外层统一调用此方法 → 把 inputBox 的文本解析并写回 BE
-        if (inputBox != null) {
-            String txt = inputBox.getValue();
-            if (txt != null && !txt.isEmpty()) {
-                try {
-                    if (isInt) {
-                        int iv = Integer.parseInt(txt.trim());
-                        value = clamp(iv);
-                    } else {
-                        float fv = Float.parseFloat(txt.trim());
-                        value = clamp(fv);
-                    }
-                } catch (NumberFormatException ignored) {
-                    // 解析失败则不改变 value（或可选择设置为 default）
-                }
-            }
-        }
-        // 最终写回 BE（由你传入的 setter 处理具体写法）
-        setter.accept(be, value);
     }
 
     /* ============ 辅助 ============ */

--- a/common/src/main/java/com/fangsu/extraConfig/StringConfig.java
+++ b/common/src/main/java/com/fangsu/extraConfig/StringConfig.java
@@ -30,13 +30,18 @@ public class StringConfig extends ConfigEntry<String> {
                 y,
                 fieldW,
                 height,
-                value
+                value,
+                text -> {
+                    value = text;
+                    notifyValueChanged();
+                }
         );
 
         return new ConfigWidget(
                 x, y,
                 labelW + fieldW,
                 height,
+                labelW,
                 title,
                 widget
         );

--- a/common/src/main/java/com/fangsu/ui/ObjBlockConfigScreen.java
+++ b/common/src/main/java/com/fangsu/ui/ObjBlockConfigScreen.java
@@ -73,6 +73,8 @@ public class ObjBlockConfigScreen extends Screen {
         int areaLeft = 40;
         int areaRight = this.width - 40;
         int contentWidth = areaRight - areaLeft;
+        int labelW = (int) (contentWidth * 0.4f);
+        int fieldW = contentWidth - labelW;
 
         int leftX = areaLeft;
 
@@ -110,11 +112,14 @@ public class ObjBlockConfigScreen extends Screen {
         if (be.getConfigs() != null) {
             entries.add(new ScrollEntry(createTextLabel(cx, y, Component.translatable("ui.fangsu.block.extras").getString(), TextLabel.Align.CENTER, 0xFFFFFF, false), y));
             y += 12;
-            int labelW = (int) (width * 0.45);
-            int fieldW = (int) (width * 0.45);
-
             for (ConfigEntry<?> c : configs) {
                 c.load(be);
+                c.setChangeListener(entry -> {
+                    if (entry.isSaveOnChange()) {
+                        entry.save(be);
+                        be.sendUpdateC2S();
+                    }
+                });
                 if (!c.isVisible(be)) {
                     continue;
                 }


### PR DESCRIPTION
### Motivation
- Ensure collision/outline voxel shapes match rendering by applying model rotation before translation so transforms are consistent and stable.
- Simplify the numeric single-line input UI by removing the extra slider state and rely on the `EditBox` responder for live updates.
- Provide per-entry immediate-save hooks so some config entries can persist changes instantly when their value changes.

### Description
- Change collision transform order in `BlockEntityTicketBarrier`: compute rotated shapes via `CollisionBoxUtil.cachedRotatedShape(...)` then apply translation with `VoxelShape.move(...)` instead of translating the `CollisionBox` before rotation.
- Simplify `NumberInputConfig` to use only a single `EditBox` and update the entry value directly from the edit responder, removing the old saved `inputBox` field and the separate `save()` parsing logic.
- Add per-entry autosave support in `ConfigEntry` by introducing `setSaveOnChange(boolean)`, `isSaveOnChange()`, `setChangeListener(...)`, and `notifyValueChanged()` to trigger listeners.
- Update `ConfigWidget` to accept and render a left `labelWidth` and to align/truncate labels so controls align consistently.
- Wire up `notifyValueChanged()` calls in UI-backed entries and widgets (`BoolConfig`, `EnumConfig`, `NumberConfig`, `NumberInputConfig`, `StringConfig`, `MultiLineTextWidget`) so changes notify listeners.
- In `ObjBlockConfigScreen`, compute `labelW`/`fieldW` for layout and register change listeners for each `ConfigEntry` so that entries with `isSaveOnChange()` call `entry.save(be)` and `be.sendUpdateC2S()` immediately.

### Testing
- No automated tests were run on these changes.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69821782f634832e8e6506e6fe72c8bb)