### PR TITLE
Fix config interaction and switch UI labels to translatable components

### DIFF
--- a/common/src/main/java/com/fangsu/blockEntities/BlockEntityTicketBarrier.java
+++ b/common/src/main/java/com/fangsu/blockEntities/BlockEntityTicketBarrier.java
@@ -283,24 +283,24 @@ public class BlockEntityTicketBarrier extends BaseObjBlockEntity {
         List<ConfigEntry<?>> configs = new ArrayList<>();
         Map<String, String> extra = this.extraConfigs;
         configs.add(new EnumConfig(
-                Component.literal("模式"),
+                Component.translatable("ui.fangsu.ticketbarrier.mode"),
                 new ConfigSpec("list"),
                 List.of(
-                        Component.literal("ui.fangsu.ticketbarrier.modeMtr"),
-                        Component.literal("ui.fangsu.ticketbarrier.modeFareOnce"),
-                        Component.literal("ui.fangsu.ticketbarrier.modeCustom")
+                        Component.translatable("ui.fangsu.ticketbarrier.modeMtr"),
+                        Component.translatable("ui.fangsu.ticketbarrier.modeFareOnce"),
+                        Component.translatable("ui.fangsu.ticketbarrier.modeCustom")
                 ),
                 be -> getExtraConfigInt("fareType", 0),
                 (be, v) -> extra.put("fareType", v.toString())
         ).setSaveOnChange(true));
         configs.add(new BoolConfig(
-                Component.literal("ui.fangsu.ticketbarrier.isExit"),
+                Component.translatable("ui.fangsu.ticketbarrier.isExit"),
                 new ConfigSpec("bool"),
                 be -> getExtraConfigBool("isExit", false),
                 (be, v) -> extra.put("isExit", v.toString())
         ).setShowCondition(v -> 0 == getExtraConfigInt("fareType", 0)));
         configs.add(new NumberInputConfig(
-                Component.literal("ui.fangsu.ticketbarrier.fareVal"),
+                Component.translatable("ui.fangsu.ticketbarrier.fareVal"),
                 new ConfigSpec("number_input")
                         .setParam("max", new JsonPrimitive(32767))
                         .setParam("min", new JsonPrimitive(0))

--- a/common/src/main/java/com/fangsu/extraConfig/BoolConfig.java
+++ b/common/src/main/java/com/fangsu/extraConfig/BoolConfig.java
@@ -33,6 +33,8 @@ public class BoolConfig extends ConfigEntry<Boolean> {
     }
 
     private Component label() {
-        return Component.literal(value ? "ON" : "OFF");
+        return Component.translatable(value
+                ? "ui.fangsu.common.on"
+                : "ui.fangsu.common.off");
     }
 }

--- a/common/src/main/java/com/fangsu/extraConfig/ConfigTypes.java
+++ b/common/src/main/java/com/fangsu/extraConfig/ConfigTypes.java
@@ -96,7 +96,7 @@ public final class ConfigTypes {
          */
         var arr = spec.params.get("values").getAsJsonArray();
         List<MutableComponent> values = arr.asList().stream()
-                .map(e -> Component.literal(e.getAsString()))
+                .map(e -> Component.translatable(e.getAsString()))
                 .toList();
 
         return new EnumConfig(title, spec, values, getter, setter);

--- a/common/src/main/java/com/fangsu/extraConfig/ConfigWidget.java
+++ b/common/src/main/java/com/fangsu/extraConfig/ConfigWidget.java
@@ -36,6 +36,9 @@ public class ConfigWidget extends AbstractWidget {
 
     @Override
     public boolean mouseClicked(double mouseX, double mouseY, int button) {
+        if (!visible || !active) {
+            return false;
+        }
         return forwardToChildren(widget -> {
             if (widget.mouseClicked(mouseX, mouseY, button)) {
                 syncFocus(widget);
@@ -47,21 +50,33 @@ public class ConfigWidget extends AbstractWidget {
 
     @Override
     public boolean mouseReleased(double mouseX, double mouseY, int button) {
+        if (!visible || !active) {
+            return false;
+        }
         return forwardToChildren(w -> w.mouseReleased(mouseX, mouseY, button));
     }
 
     @Override
     public boolean mouseDragged(double mouseX, double mouseY, int button, double dx, double dy) {
+        if (!visible || !active) {
+            return false;
+        }
         return forwardToChildren(w -> w.mouseDragged(mouseX, mouseY, button, dx, dy));
     }
 
     @Override
     public boolean keyPressed(int keyCode, int scanCode, int modifiers) {
+        if (!visible || !active) {
+            return false;
+        }
         return forwardToChildren(w -> w.isFocused() && w.keyPressed(keyCode, scanCode, modifiers));
     }
 
     @Override
     public boolean charTyped(char codePoint, int modifiers) {
+        if (!visible || !active) {
+            return false;
+        }
         return forwardToChildren(w -> w.isFocused() && w.charTyped(codePoint, modifiers));
     }
 

--- a/common/src/main/java/com/fangsu/extraConfig/NumberConfig.java
+++ b/common/src/main/java/com/fangsu/extraConfig/NumberConfig.java
@@ -77,7 +77,7 @@ public class NumberConfig extends ConfigEntry<Float> {
         /* ---------- Toggle ---------- */
 
         Button toggle = Button.builder(
-                Component.literal("≡"),
+                Component.translatable("ui.fangsu.common.toggle_input"),
                 b -> {
                     slider.visible = !slider.visible;
                     input.visible = !input.visible;

--- a/common/src/main/java/com/fangsu/extraConfig/SliderWidget.java
+++ b/common/src/main/java/com/fangsu/extraConfig/SliderWidget.java
@@ -99,7 +99,8 @@ public class SliderWidget extends AbstractWidget {
         @Override
         protected void updateMessage() {
             setMessage(
-                    Component.literal(
+                    Component.translatable(
+                            "ui.fangsu.common.value",
                             format(denormalize(value))
                     )
             );

--- a/common/src/main/java/com/fangsu/ui/ObjBlockConfigScreen.java
+++ b/common/src/main/java/com/fangsu/ui/ObjBlockConfigScreen.java
@@ -39,7 +39,7 @@ public class ObjBlockConfigScreen extends Screen {
     private boolean pendingRebuild = false;
 
     public ObjBlockConfigScreen(BaseObjBlockEntity be) {
-        super(Component.literal("方块配置"));
+        super(Component.translatable("ui.fangsu.block.title"));
         this.be = be;
 
         // 从 BE 读取初始值（防空）
@@ -85,16 +85,28 @@ public class ObjBlockConfigScreen extends Screen {
         }).bounds(this.width - 170, 34, 130, 20).build();
         addRenderableWidget(toggleInputButton);
 
-        addEntry(createTextLabel(cx, y, Component.translatable("ui.fangsu.block.translate").getString(), TextLabel.Align.CENTER, 0xFFFFFF, false), y);
+        addEntry(createTextLabel(cx, y, Component.translatable("ui.fangsu.block.translate"), TextLabel.Align.CENTER, 0xFFFFFF, false), y);
         y += 12;
-        y = addAxisControls(cx, spacing, y, "X", "Y", "Z",
+        y = addAxisControls(cx, spacing, y,
+                Component.translatable("ui.fangsu.block.transX"),
+                Component.translatable("ui.fangsu.block.transY"),
+                Component.translatable("ui.fangsu.block.transZ"),
+                translateX,
+                translateY,
+                translateZ,
                 -1, 1, 0.0625f,
                 v -> translateX = v,
                 v -> translateY = v,
                 v -> translateZ = v);
         y += 28;
 
-        y = addAxisControls(cx, spacing, y, "RX", "RY", "RZ",
+        y = addAxisControls(cx, spacing, y,
+                Component.translatable("ui.fangsu.block.rotX"),
+                Component.translatable("ui.fangsu.block.rotY"),
+                Component.translatable("ui.fangsu.block.rotZ"),
+                rotateX,
+                rotateY,
+                rotateZ,
                 -180, 180, 5,
                 v -> rotateX = v,
                 v -> rotateY = v,
@@ -102,7 +114,7 @@ public class ObjBlockConfigScreen extends Screen {
         y += 28;
 
         if (!configs.isEmpty()) {
-            addEntry(createTextLabel(cx, y, Component.translatable("ui.fangsu.block.extras").getString(), TextLabel.Align.CENTER, 0xFFFFFF, false), y);
+            addEntry(createTextLabel(cx, y, Component.translatable("ui.fangsu.block.extras"), TextLabel.Align.CENTER, 0xFFFFFF, false), y);
             y += 12;
             for (ConfigEntry<?> c : configs) {
                 c.load(be);
@@ -110,8 +122,8 @@ public class ObjBlockConfigScreen extends Screen {
                     if (entry.isSaveOnChange()) {
                         entry.save(be);
                         be.sendUpdateC2S();
+                        requestRebuild();
                     }
-                    requestRebuild();
                 });
                 if (!c.isVisible(be)) {
                     continue;
@@ -123,7 +135,7 @@ public class ObjBlockConfigScreen extends Screen {
             }
         }
 
-        closeButton = this.addRenderableWidget(Button.builder(Component.literal("关闭并保存"),
+        closeButton = this.addRenderableWidget(Button.builder(Component.translatable("ui.fangsu.block.close_and_save"),
                 btn -> {
                     if (!REALTIME) sendToServer();
                     onClose();
@@ -132,7 +144,9 @@ public class ObjBlockConfigScreen extends Screen {
     }
 
     private Component getInputToggleLabel() {
-        return Component.literal(useSliderInput ? "切换为输入框" : "切换为滑块");
+        return Component.translatable(useSliderInput
+                ? "ui.fangsu.block.toggle_input"
+                : "ui.fangsu.block.toggle_slider");
     }
 
     private void requestRebuild() {
@@ -143,9 +157,12 @@ public class ObjBlockConfigScreen extends Screen {
             int centerX,
             int spacing,
             int baseY,
-            String labelX,
-            String labelY,
-            String labelZ,
+            Component labelX,
+            Component labelY,
+            Component labelZ,
+            float valueX,
+            float valueY,
+            float valueZ,
             float min,
             float max,
             float step,
@@ -154,42 +171,30 @@ public class ObjBlockConfigScreen extends Screen {
             Consumer<Float> setZ
     ) {
         if (useSliderInput) {
-            addEntry(createSlider(centerX - spacing, baseY, labelX, getAxisValue(labelX), v -> {
+            addEntry(createSlider(centerX - spacing, baseY, valueX, v -> {
                 setX.accept(v);
                 if (REALTIME) sendToServer();
             }, min, max, step), baseY);
-            addEntry(createSlider(centerX, baseY, labelY, getAxisValue(labelY), v -> {
+            addEntry(createSlider(centerX, baseY, valueY, v -> {
                 setY.accept(v);
                 if (REALTIME) sendToServer();
             }, min, max, step), baseY);
-            addEntry(createSlider(centerX + spacing, baseY, labelZ, getAxisValue(labelZ), v -> {
+            addEntry(createSlider(centerX + spacing, baseY, valueZ, v -> {
                 setZ.accept(v);
                 if (REALTIME) sendToServer();
             }, min, max, step), baseY);
             return baseY;
         }
-        addEntry(createAxisInput(centerX - spacing, baseY, labelX, getAxisValue(labelX), min, max, step, setX), baseY);
-        addEntry(createAxisInput(centerX, baseY, labelY, getAxisValue(labelY), min, max, step, setY), baseY);
-        addEntry(createAxisInput(centerX + spacing, baseY, labelZ, getAxisValue(labelZ), min, max, step, setZ), baseY);
+        addEntry(createAxisInput(centerX - spacing, baseY, labelX, valueX, min, max, step, setX), baseY);
+        addEntry(createAxisInput(centerX, baseY, labelY, valueY, min, max, step, setY), baseY);
+        addEntry(createAxisInput(centerX + spacing, baseY, labelZ, valueZ, min, max, step, setZ), baseY);
         return baseY;
-    }
-
-    private float getAxisValue(String label) {
-        return switch (label) {
-            case "X" -> translateX;
-            case "Y" -> translateY;
-            case "Z" -> translateZ;
-            case "RX" -> rotateX;
-            case "RY" -> rotateY;
-            case "RZ" -> rotateZ;
-            default -> 0f;
-        };
     }
 
     private AbstractWidget createAxisInput(
             int x,
             int baseY,
-            String label,
+            Component label,
             float initialValue,
             float min,
             float max,
@@ -218,13 +223,13 @@ public class ObjBlockConfigScreen extends Screen {
     /**
      * 创建带步进的滑块。
      */
-    private SliderWidget createSlider(int cx, int baseY, String label, float initialValue, Consumer<Float> setter, float min, float max, float step) {
+    private SliderWidget createSlider(int cx, int baseY, float initialValue, Consumer<Float> setter, float min, float max, float step) {
         SliderWidget slider = new SliderWidget(cx - 30, baseY, 60, 20, Component.empty(), initialValue, min, max, step, setter);
         this.addRenderableWidget(slider);
         return slider;
     }
 
-    private TextLabel createTextLabel(int x, int y, String text, TextLabel.Align align, int color, boolean bold) {
+    private TextLabel createTextLabel(int x, int y, Component text, TextLabel.Align align, int color, boolean bold) {
         TextLabel label = new TextLabel(x, y, text, align, color, bold);
         this.addRenderableWidget(label);
         return label;
@@ -264,10 +269,10 @@ public class ObjBlockConfigScreen extends Screen {
         graphics.fill(areaLeft, areaTop, areaRight, areaBottom, 0xCCFFFFFF); // 半透明白
 
         // 标题（居中，使用深色文本以便在浅底上清晰显示）
-        String title = this.title.getString();
-        int titleX = this.width / 2 - this.font.width(title) / 2;
+        String titleText = this.title.getString();
+        int titleX = this.width / 2 - this.font.width(titleText) / 2;
         int titleY = areaTop - 18;
-        graphics.drawString(this.font, Component.literal(title), titleX, titleY, 0x101010, false);
+        graphics.drawString(this.font, this.title, titleX, titleY, 0x101010, false);
 
         // 在渲染每一帧之前，给 sliders 应用 scrollOffset —— 修改它们的 y 值
         for (ScrollEntry e : entries) {
@@ -348,12 +353,12 @@ public class ObjBlockConfigScreen extends Screen {
     private static class TextLabel extends AbstractWidget {
         public enum Align {LEFT, CENTER, RIGHT}
 
-        private final String text;
+        private final Component text;
         private final int color;
         private final boolean bold;
         private final Align align;
 
-        public TextLabel(int x, int y, String text, Align align, int color, boolean bold) {
+        public TextLabel(int x, int y, Component text, Align align, int color, boolean bold) {
             super(x, y, 0, 0, Component.empty());
             this.text = text;
             this.align = align;
@@ -367,7 +372,8 @@ public class ObjBlockConfigScreen extends Screen {
             int drawX = this.getX();
 
             // 根据对齐方式调整 x
-            int textWidth = font.width(text);
+            String labelText = text.getString();
+            int textWidth = font.width(labelText);
             switch (align) {
                 case CENTER -> drawX = this.getX() - textWidth / 2;
                 case RIGHT -> drawX = this.getX() - textWidth;
@@ -376,7 +382,7 @@ public class ObjBlockConfigScreen extends Screen {
 
             // 绘制文本，可加粗
             if (bold) {
-                graphics.drawString(font, Component.literal(text).withStyle(style -> style.withBold(true)), drawX, this.getY(), color, false);
+                graphics.drawString(font, text.copy().withStyle(style -> style.withBold(true)), drawX, this.getY(), color, false);
             } else {
                 graphics.drawString(font, text, drawX, this.getY(), color, false);
             }

--- a/common/src/main/resources/assets/fangsu/lang/en_us.json
+++ b/common/src/main/resources/assets/fangsu/lang/en_us.json
@@ -1,3 +1,24 @@
 {
-  "ui.fangsu.block.title": "Block Config"
+  "ui.fangsu.block.title": "Block Config",
+  "ui.fangsu.block.transX": "X Offset",
+  "ui.fangsu.block.transY": "Y Offset",
+  "ui.fangsu.block.transZ": "Z Offset",
+  "ui.fangsu.block.rotX": "X Rotation",
+  "ui.fangsu.block.rotY": "Y Rotation",
+  "ui.fangsu.block.rotZ": "Z Rotation",
+  "ui.fangsu.block.translate": "Object Offset",
+  "ui.fangsu.block.extras": "Extra Settings",
+  "ui.fangsu.block.toggle_input": "Switch to Input",
+  "ui.fangsu.block.toggle_slider": "Switch to Slider",
+  "ui.fangsu.block.close_and_save": "Close & Save",
+  "ui.fangsu.ticketbarrier.mode": "Mode",
+  "ui.fangsu.ticketbarrier.isExit": "Exit Gate",
+  "ui.fangsu.ticketbarrier.fareVal": "Fare Amount",
+  "ui.fangsu.ticketbarrier.modeMtr": "MTR Fare",
+  "ui.fangsu.ticketbarrier.modeFareOnce": "Flat Fare",
+  "ui.fangsu.ticketbarrier.modeCustom": "Custom (TBD)",
+  "ui.fangsu.common.on": "ON",
+  "ui.fangsu.common.off": "OFF",
+  "ui.fangsu.common.toggle_input": "≡",
+  "ui.fangsu.common.value": "%s"
 }

--- a/common/src/main/resources/assets/fangsu/lang/zh_cn.json
+++ b/common/src/main/resources/assets/fangsu/lang/zh_cn.json
@@ -9,10 +9,18 @@
   "ui.fangsu.block.config": "物件配置",
   "ui.fangsu.block.translate": "物件偏移",
   "ui.fangsu.block.extras": "物件额外配置",
+  "ui.fangsu.block.toggle_input": "切换为输入框",
+  "ui.fangsu.block.toggle_slider": "切换为滑块",
+  "ui.fangsu.block.close_and_save": "关闭并保存",
+  "ui.fangsu.ticketbarrier.mode": "模式",
   "ui.fangsu.ticketbarrier.isExit": "是否为出口",
   "ui.fangsu.ticketbarrier.fareVal": "扣款金额",
   "ui.fangsu.ticketbarrier.modeMtr": "MTR计费",
   "ui.fangsu.ticketbarrier.modeFareOnce": "固定收费",
   "ui.fangsu.ticketbarrier.modeCustom": "自定义(还没做)",
+  "ui.fangsu.common.on": "开",
+  "ui.fangsu.common.off": "关",
+  "ui.fangsu.common.toggle_input": "≡",
+  "ui.fangsu.common.value": "%s",
   "msg.fangsu.ticketbarrier.fareOnce": "扣费 %s 余额 %s"
 }


### PR DESCRIPTION
### Motivation
- Fix a bug where config controls (e.g. fare amount and "is exit") were not responding to clicks/inputs and convert all visible text to translatable components so the UI can be localized.

### Description
- Update `ObjBlockConfigScreen` to use `Component.translatable` for the screen title, axis labels, section headers, toggle/close buttons, and to pass numeric values to sliders/inputs instead of deriving them from label strings, and avoid rebuilding the UI on non-save changes so inputs remain responsive.
- Make `ConfigWidget` ignore forwarded events when the widget is not `visible` or not `active` to prevent child widgets from receiving stray events.
- Localize config controls: change `BoolConfig` on/off label to `Component.translatable`, change `NumberConfig` toggle label to translatable, change `SliderWidget` value message to a translatable format, and make `ConfigTypes` list values translatable.
- Replace literal component usage in `BlockEntityTicketBarrier#getConfigs()` with translatable components and add corresponding keys in `en_us.json` and `zh_cn.json`.

### Testing
- No automated tests were run for this change (`none`).

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_698557a007c0832e8c7a00ad24bcb7aa)