### PR TITLE
Support multi-neighbor collision compensation and interaction forwarding

### DIFF
--- a/common/src/main/java/com/fangsu/blocks/BlockCollisionCompensator.java
+++ b/common/src/main/java/com/fangsu/blocks/BlockCollisionCompensator.java
@@ -1,0 +1,164 @@
+package com.fangsu.blocks;
+
+import net.minecraft.core.BlockPos;
+import net.minecraft.core.Direction;
+import net.minecraft.world.InteractionHand;
+import net.minecraft.world.InteractionResult;
+import net.minecraft.world.entity.player.Player;
+import net.minecraft.world.item.context.BlockPlaceContext;
+import net.minecraft.world.level.BlockGetter;
+import net.minecraft.world.level.Level;
+import net.minecraft.world.level.block.Block;
+import net.minecraft.world.level.block.RenderShape;
+import net.minecraft.world.level.block.state.BlockBehaviour;
+import net.minecraft.world.level.block.state.BlockState;
+import net.minecraft.world.level.block.state.StateDefinition;
+import net.minecraft.world.level.block.state.properties.DirectionProperty;
+import net.minecraft.world.phys.BlockHitResult;
+import net.minecraft.world.phys.Vec3;
+import net.minecraft.world.phys.shapes.BooleanOp;
+import net.minecraft.world.phys.shapes.CollisionContext;
+import net.minecraft.world.phys.shapes.Shapes;
+import net.minecraft.world.phys.shapes.VoxelShape;
+import net.minecraft.world.phys.AABB;
+import org.jetbrains.annotations.NotNull;
+import org.jetbrains.annotations.Nullable;
+
+public class BlockCollisionCompensator extends Block {
+    public static final DirectionProperty TARGET_DIRECTION = DirectionProperty.create("target_direction", Direction.values());
+
+    public BlockCollisionCompensator(Properties properties) {
+        super(properties);
+        registerDefaultState(defaultBlockState().setValue(TARGET_DIRECTION, Direction.DOWN));
+    }
+
+    public BlockCollisionCompensator() {
+        this(BlockBehaviour.Properties.of().strength(2).noOcclusion());
+    }
+
+    @Override
+    protected void createBlockStateDefinition(StateDefinition.Builder<Block, BlockState> builder) {
+        builder.add(TARGET_DIRECTION);
+    }
+
+    @Override
+    public @Nullable BlockState getStateForPlacement(BlockPlaceContext context) {
+        Direction targetDirection = context.getClickedFace().getOpposite();
+        return defaultBlockState().setValue(TARGET_DIRECTION, targetDirection);
+    }
+
+    @Override
+    public @NotNull RenderShape getRenderShape(@NotNull BlockState state) {
+        return RenderShape.INVISIBLE;
+    }
+
+    @Override
+    public @NotNull InteractionResult use(
+            @NotNull BlockState state,
+            @NotNull Level level,
+            @NotNull BlockPos pos,
+            @NotNull Player player,
+            @NotNull InteractionHand hand,
+            @NotNull BlockHitResult hit
+    ) {
+        Vec3 hitLocation = hit.getLocation();
+        BlockPos bestPos = null;
+        BlockState bestState = null;
+        double bestDistance = Double.MAX_VALUE;
+        for (Direction direction : Direction.values()) {
+            BlockPos targetPos = pos.relative(direction);
+            BlockState targetState = level.getBlockState(targetPos);
+            if (targetState.getBlock() == this) {
+                continue;
+            }
+            VoxelShape targetShape = targetState.getShape(level, targetPos);
+            VoxelShape clippedWorld = getClippedWorldShape(targetShape, pos, targetPos);
+            if (clippedWorld.isEmpty() && !targetState.getCollisionShape(level, targetPos).isEmpty()) {
+                clippedWorld = getClippedWorldShape(targetState.getCollisionShape(level, targetPos), pos, targetPos);
+            }
+            if (clippedWorld.isEmpty() || !containsPoint(clippedWorld, hitLocation)) {
+                continue;
+            }
+            Vec3 targetCenter = new Vec3(targetPos.getX() + 0.5, targetPos.getY() + 0.5, targetPos.getZ() + 0.5);
+            double distance = targetCenter.distanceToSqr(hitLocation);
+            if (distance < bestDistance) {
+                bestDistance = distance;
+                bestPos = targetPos;
+                bestState = targetState;
+            }
+        }
+        if (bestPos == null || bestState == null) {
+            return InteractionResult.PASS;
+        }
+        BlockHitResult redirectedHit = new BlockHitResult(hitLocation, hit.getDirection(), bestPos, hit.isInside());
+        return bestState.getBlock().use(bestState, level, bestPos, player, hand, redirectedHit);
+    }
+
+    @Override
+    public @NotNull VoxelShape getCollisionShape(
+            @NotNull BlockState state,
+            @NotNull BlockGetter world,
+            @NotNull BlockPos pos,
+            @NotNull CollisionContext context
+    ) {
+        return getCompensationShape(world, pos, true);
+    }
+
+    @Override
+    public @NotNull VoxelShape getShape(
+            @NotNull BlockState state,
+            @NotNull BlockGetter world,
+            @NotNull BlockPos pos,
+            @NotNull CollisionContext context
+    ) {
+        return getCompensationShape(world, pos, false);
+    }
+
+    private VoxelShape getCompensationShape(BlockGetter world, BlockPos pos, boolean collision) {
+        VoxelShape merged = Shapes.empty();
+        for (Direction direction : Direction.values()) {
+            BlockPos targetPos = pos.relative(direction);
+            BlockState targetState = world.getBlockState(targetPos);
+            if (targetState.getBlock() == this) {
+                continue;
+            }
+            VoxelShape targetShape = collision
+                    ? targetState.getCollisionShape(world, targetPos)
+                    : targetState.getShape(world, targetPos);
+            if (targetShape.isEmpty()) {
+                continue;
+            }
+            VoxelShape clippedLocal = getClippedLocalShape(targetShape, pos, targetPos);
+            if (!clippedLocal.isEmpty()) {
+                merged = Shapes.or(merged, clippedLocal);
+            }
+        }
+        return merged;
+    }
+
+    private VoxelShape getClippedLocalShape(VoxelShape targetShape, BlockPos pos, BlockPos targetPos) {
+        VoxelShape clippedWorld = getClippedWorldShape(targetShape, pos, targetPos);
+        if (clippedWorld.isEmpty()) {
+            return Shapes.empty();
+        }
+        return clippedWorld.move(-pos.getX(), -pos.getY(), -pos.getZ());
+    }
+
+    private VoxelShape getClippedWorldShape(VoxelShape targetShape, BlockPos pos, BlockPos targetPos) {
+        if (targetShape.isEmpty()) {
+            return Shapes.empty();
+        }
+        VoxelShape targetWorldShape = targetShape.move(targetPos.getX(), targetPos.getY(), targetPos.getZ());
+        VoxelShape blockWorldShape = Shapes.block().move(pos.getX(), pos.getY(), pos.getZ());
+        return Shapes.joinUnoptimized(targetWorldShape, blockWorldShape, BooleanOp.AND);
+    }
+
+    private boolean containsPoint(VoxelShape shape, Vec3 point) {
+        for (AABB box : shape.toAabbs()) {
+            if (box.contains(point)) {
+                return true;
+            }
+        }
+        return false;
+    }
+}

--- a/common/src/main/java/com/fangsu/blocks/ModBlocks.java
+++ b/common/src/main/java/com/fangsu/blocks/ModBlocks.java
@@ -17,7 +17,18 @@ public class ModBlocks {
 
     public static final RegistrySupplier<Item> ITEM_TICKET_BARRIER = RegisterUtil.addBlockItem("ticket_barrier", BLOCK_TICKET_BARRIER);
 
-    public static final RegistrySupplier<CreativeModeTab> FANGSU_MAIN = RegisterUtil.addCreativeTab("main", "tab", ITEM_TICKET_BARRIER, ITEM_TICKET_BARRIER);
+    public static final RegistrySupplier<Block> BLOCK_COLLISION_COMPENSATOR =
+            RegisterUtil.addBlock("collision_compensation_block", BlockCollisionCompensator::new);
+    public static final RegistrySupplier<Item> ITEM_COLLISION_COMPENSATOR =
+            RegisterUtil.addBlockItem("collision_compensation_block", BLOCK_COLLISION_COMPENSATOR);
+
+    public static final RegistrySupplier<CreativeModeTab> FANGSU_MAIN = RegisterUtil.addCreativeTab(
+            "main",
+            "tab",
+            ITEM_TICKET_BARRIER,
+            ITEM_TICKET_BARRIER,
+            ITEM_COLLISION_COMPENSATOR
+    );
 
     public static void init() {
     }

--- a/common/src/main/resources/assets/fangsu/lang/en_us.json
+++ b/common/src/main/resources/assets/fangsu/lang/en_us.json
@@ -20,5 +20,6 @@
   "ui.fangsu.common.on": "ON",
   "ui.fangsu.common.off": "OFF",
   "ui.fangsu.common.toggle_input": "≡",
-  "ui.fangsu.common.value": "%s"
+  "ui.fangsu.common.value": "%s",
+  "block.fangsu.collision_compensation_block": "碰撞箱补偿方块"
 }


### PR DESCRIPTION
### Motivation
- The compensation block must account for collision/outline extents that fall into this block from multiple adjacent blocks and must work regardless of placement order. 

### Description
- Updated `BlockCollisionCompensator` to aggregate clipped shapes from all adjacent blocks by iterating `Direction.values()` and merging per-neighbor clipped shapes via `Shapes.or` (`getCompensationShape`, `getClippedLocalShape`, `getClippedWorldShape`).
- Interaction handling now finds the nearest adjacent block whose clipped world-space shape contains the hit point and forwards a redirected `BlockHitResult` to that block (`use` override, `containsPoint` helper).
- Registered the compensator block and item in `ModBlocks` and added the item into the creative tab, and added the translation key `block.fangsu.collision_compensation_block` to `en_us.json`.

### Testing
- No automated tests were executed for these changes.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6987355c144c832ea7bf5a1b81e57e59)