### PR TITLE
Limit collision compensation to ObjBasedBlock interactions and remap forwarded hits

### DIFF
--- a/common/src/main/java/com/fangsu/blocks/BlockCollisionCompensator.java
+++ b/common/src/main/java/com/fangsu/blocks/BlockCollisionCompensator.java
@@ -61,7 +61,8 @@ public class BlockCollisionCompensator extends Block {
                     }
                     BlockPos targetPos = pos.offset(dx, dy, dz);
                     BlockState targetState = level.getBlockState(targetPos);
-                    if (targetState.getBlock() == this) {
+                    Block targetBlock = targetState.getBlock();
+                    if (targetBlock == this || !isObjBasedBlock(targetBlock)) {
                         continue;
                     }
                     VoxelShape interactionShape = targetState.getInteractionShape(level, targetPos);
@@ -89,7 +90,8 @@ public class BlockCollisionCompensator extends Block {
             return InteractionResult.PASS;
         }
         Direction redirectedDirection = resolveHitDirection(bestWorldShape, hitLocation, hit.getDirection());
-        BlockHitResult redirectedHit = new BlockHitResult(hitLocation, redirectedDirection, bestPos, hit.isInside());
+        Vec3 redirectedLocation = redirectHitLocation(hitLocation, pos, bestPos);
+        BlockHitResult redirectedHit = new BlockHitResult(redirectedLocation, redirectedDirection, bestPos, hit.isInside());
         return bestState.getBlock().use(bestState, level, bestPos, player, hand, redirectedHit);
     }
 
@@ -127,7 +129,8 @@ public class BlockCollisionCompensator extends Block {
                     }
                     BlockPos targetPos = pos.offset(dx, dy, dz);
                     BlockState targetState = world.getBlockState(targetPos);
-                    if (targetState.getBlock() == this) {
+                    Block targetBlock = targetState.getBlock();
+                    if (targetBlock == this || !isObjBasedBlock(targetBlock)) {
                         continue;
                     }
                     VoxelShape targetShape = collision
@@ -177,6 +180,24 @@ public class BlockCollisionCompensator extends Block {
             return Shapes.empty();
         }
         return shape.move(targetPos.getX(), targetPos.getY(), targetPos.getZ());
+    }
+
+    private Vec3 redirectHitLocation(Vec3 hitLocation, BlockPos sourcePos, BlockPos targetPos) {
+        double offsetX = targetPos.getX() - sourcePos.getX();
+        double offsetY = targetPos.getY() - sourcePos.getY();
+        double offsetZ = targetPos.getZ() - sourcePos.getZ();
+        return hitLocation.add(offsetX, offsetY, offsetZ);
+    }
+
+    private boolean isObjBasedBlock(Block block) {
+        Class<?> currentClass = block.getClass();
+        while (currentClass != null) {
+            if ("ObjBasedBlock".equals(currentClass.getSimpleName())) {
+                return true;
+            }
+            currentClass = currentClass.getSuperclass();
+        }
+        return false;
     }
 
     private boolean containsPoint(VoxelShape shape, Vec3 point) {


### PR DESCRIPTION
### Motivation
- Prevent the compensator from handling collisions and interaction forwarding for arbitrary blocks and restrict it to blocks derived from `ObjBasedBlock` only.
- Improve forwarded interaction fidelity by determining the actual source `ObjBasedBlock` and remapping click positions before forwarding instead of naively reusing the original hit.

### Description
- Skip non-`ObjBasedBlock` instances and self when searching nearby blocks in `use` and `getCompensationShape` by calling the new helper `isObjBasedBlock`.
- Add `redirectHitLocation` to translate the hit `Vec3` from the compensator's coordinate to the target block's coordinate and use the translated location when creating the forwarded `BlockHitResult` in `use`.
- Implement `isObjBasedBlock` using runtime class-name inspection to detect types named `ObjBasedBlock` in the inheritance chain.
- Restrict shape merging logic in `getCompensationShape` to only include clipped shapes from `ObjBasedBlock` targets.

### Testing
- No automated tests were run for this change.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69874668bac4832e86883412ea8eb333)