### PR TITLE
Extract BasicConfigScreen, make ObjBlockConfigScreen extend it, add SignConfigUI

### DIFF
--- a/common/src/main/java/com/fangsu/ui/BasicConfigScreen.java
+++ b/common/src/main/java/com/fangsu/ui/BasicConfigScreen.java
@@ -1,0 +1,350 @@
+package com.fangsu.ui;
+
+import com.fangsu.extraConfig.SliderWidget;
+import net.minecraft.client.Minecraft;
+import net.minecraft.client.gui.GuiGraphics;
+import net.minecraft.client.gui.components.AbstractWidget;
+import net.minecraft.client.gui.components.Button;
+import net.minecraft.client.gui.components.EditBox;
+import net.minecraft.client.gui.narration.NarrationElementOutput;
+import net.minecraft.client.gui.screens.Screen;
+import net.minecraft.network.chat.Component;
+import net.minecraft.util.Mth;
+import org.jetbrains.annotations.NotNull;
+
+import java.util.ArrayList;
+import java.util.List;
+import java.util.function.Consumer;
+
+public abstract class BasicConfigScreen extends Screen {
+
+    protected int scrollOffset = 0;
+    private boolean pendingRebuild = false;
+
+    protected Button closeButton;
+    protected final List<AbstractWidget> fixedWidgets = new ArrayList<>();
+    protected final List<ScrollEntry> entries = new ArrayList<>();
+
+    protected BasicConfigScreen(Component title) {
+        super(title);
+    }
+
+    @Override
+    protected void init() {
+        super.init();
+        entries.clear();
+        fixedWidgets.clear();
+        buildFixedWidgets();
+        buildScrollableContent(new ContentLayout(this));
+    }
+
+    protected abstract void buildScrollableContent(ContentLayout layout);
+
+    protected void buildFixedWidgets() {
+        closeButton = addFixedWidget(Button.builder(Component.translatable("ui.fangsu.block.close_and_save"), btn -> onClose())
+                .bounds(this.width / 2 - 50, this.height - 40, 100, 20).build());
+    }
+
+    protected void requestRebuild() {
+        pendingRebuild = true;
+    }
+
+    protected int addAxisControls(
+            int centerX,
+            int spacing,
+            int baseY,
+            Component labelX,
+            Component labelY,
+            Component labelZ,
+            float valueX,
+            float valueY,
+            float valueZ,
+            float min,
+            float max,
+            float step,
+            Consumer<Float> setX,
+            Consumer<Float> setY,
+            Consumer<Float> setZ,
+            Runnable onValueChanged,
+            boolean useSliderInput
+    ) {
+        if (useSliderInput) {
+            addEntry(createSlider(centerX - spacing, baseY, valueX, v -> {
+                setX.accept(v);
+                onValueChanged.run();
+            }, min, max, step), baseY);
+            addEntry(createSlider(centerX, baseY, valueY, v -> {
+                setY.accept(v);
+                onValueChanged.run();
+            }, min, max, step), baseY);
+            addEntry(createSlider(centerX + spacing, baseY, valueZ, v -> {
+                setZ.accept(v);
+                onValueChanged.run();
+            }, min, max, step), baseY);
+            return baseY;
+        }
+
+        baseY += 12;
+        addEntry(createAxisInput(centerX - spacing, baseY, labelX, valueX, min, max, step, setX, onValueChanged), baseY);
+        addEntry(createAxisInput(centerX, baseY, labelY, valueY, min, max, step, setY, onValueChanged), baseY);
+        addEntry(createAxisInput(centerX + spacing, baseY, labelZ, valueZ, min, max, step, setZ, onValueChanged), baseY);
+        return baseY;
+    }
+
+    protected AbstractWidget createAxisInput(
+            int x,
+            int baseY,
+            Component label,
+            float initialValue,
+            float min,
+            float max,
+            float step,
+            Consumer<Float> setter,
+            Runnable onValueChanged
+    ) {
+        int width = 60;
+        int height = 20;
+        int labelY = baseY - 10;
+        addEntry(createTextLabel(x, labelY, label, TextLabel.Align.CENTER, 0xFFFFFF, false), labelY);
+        EditBox box = new EditBox(this.font, x - width / 2, baseY, width, height, Component.empty());
+        box.setValue(formatValue(initialValue));
+        box.setResponder(text -> {
+            Float value = parseFloat(text);
+            if (value == null) {
+                return;
+            }
+            float snapped = snap(value, min, max, step);
+            setter.accept(snapped);
+            onValueChanged.run();
+        });
+        this.addRenderableWidget(box);
+        return box;
+    }
+
+    protected SliderWidget createSlider(int cx, int baseY, float initialValue, Consumer<Float> setter, float min, float max, float step) {
+        SliderWidget slider = new SliderWidget(cx - 30, baseY, 60, 20, Component.empty(), initialValue, min, max, step, setter);
+        this.addRenderableWidget(slider);
+        return slider;
+    }
+
+    protected TextLabel createTextLabel(int x, int y, Component text, TextLabel.Align align, int color, boolean bold) {
+        TextLabel label = new TextLabel(x, y, text, align, color, bold);
+        this.addRenderableWidget(label);
+        return label;
+    }
+
+    protected void addEntry(AbstractWidget widget, int baseY) {
+        entries.add(new ScrollEntry(widget, baseY));
+    }
+
+    protected Button addButton(int x, int y, int width, int height, Component label, Button.OnPress onPress) {
+        Button button = Button.builder(label, onPress).bounds(x, y, width, height).build();
+        addRenderableWidget(button);
+        return button;
+    }
+
+    protected Button addFixedWidget(Button button) {
+        addRenderableWidget(button);
+        fixedWidgets.add(button);
+        return button;
+    }
+
+    @Override
+    public void render(GuiGraphics graphics, int mouseX, int mouseY, float partialTick) {
+        if (pendingRebuild) {
+            pendingRebuild = false;
+            clearWidgets();
+            init();
+        }
+        renderBackground(graphics);
+
+        int areaLeft = getPanelLeft();
+        int areaTop = getPanelTop();
+        int areaRight = getPanelRight();
+        int areaBottom = getPanelBottom();
+        graphics.fill(areaLeft, areaTop, areaRight, areaBottom, 0xCCFFFFFF);
+
+        int titleX = this.width / 2 - this.font.width(this.title.getString()) / 2;
+        int titleY = areaTop - 18;
+        graphics.drawString(this.font, this.title, titleX, titleY, 0x101010, false);
+
+        for (ScrollEntry e : entries) {
+            e.applyScroll(scrollOffset);
+        }
+
+        for (AbstractWidget fixedWidget : fixedWidgets) {
+            fixedWidget.render(graphics, mouseX, mouseY, partialTick);
+        }
+
+        graphics.enableScissor(getContentLeft(), getContentTop(), getContentRight(), getContentBottom());
+        for (ScrollEntry e : entries) {
+            e.widget.render(graphics, mouseX, mouseY, partialTick);
+        }
+        graphics.disableScissor();
+    }
+
+    @Override
+    public boolean mouseScrolled(double mouseX, double mouseY, double delta) {
+        int visibleTop = getContentTop();
+        int visibleBottom = getContentBottom();
+        int visibleHeight = visibleBottom - visibleTop;
+
+        int contentBottom = getActualContentBottom();
+        int contentTop = entries.isEmpty() ? 0 : entries.get(0).baseY;
+        int contentHeight = contentBottom - contentTop;
+
+        if (contentHeight <= visibleHeight) {
+            scrollOffset = 0;
+            return false;
+        }
+
+        scrollOffset += (int) (delta * 12);
+
+        int minOffset = visibleHeight - contentHeight;
+        scrollOffset = Mth.clamp(scrollOffset, minOffset, 0);
+        return true;
+    }
+
+    protected int getPanelLeft() {
+        return 40;
+    }
+
+    protected int getPanelRight() {
+        return this.width - 40;
+    }
+
+    protected int getPanelTop() {
+        return 30;
+    }
+
+    protected int getPanelBottom() {
+        return this.height - 60;
+    }
+
+    protected int getContentPadding() {
+        return 12;
+    }
+
+    protected int getContentLeft() {
+        return getPanelLeft() + getContentPadding();
+    }
+
+    protected int getContentRight() {
+        return getPanelRight() - getContentPadding();
+    }
+
+    protected int getContentTop() {
+        return getPanelTop() + getContentPadding() + 12;
+    }
+
+    protected int getContentBottom() {
+        return getPanelBottom() - getContentPadding();
+    }
+
+    protected int getActualContentBottom() {
+        int bottom = 0;
+        for (ScrollEntry e : entries) {
+            bottom = Math.max(bottom, e.baseY + e.widget.getHeight());
+        }
+        return bottom;
+    }
+
+    protected Float parseFloat(String text) {
+        try {
+            return Float.parseFloat(text);
+        } catch (NumberFormatException ex) {
+            return null;
+        }
+    }
+
+    protected float snap(float value, float min, float max, float step) {
+        float clamped = Mth.clamp(value, min, max);
+        if (step <= 0) {
+            return clamped;
+        }
+        return Math.round(clamped / step) * step;
+    }
+
+    protected String formatValue(float value) {
+        return String.format("%.3f", value);
+    }
+
+    protected static class ContentLayout {
+        private final BasicConfigScreen screen;
+        public final int centerX;
+        public final int areaLeft;
+        public final int areaRight;
+        public final int contentWidth;
+        public final int labelWidth;
+        public final int fieldWidth;
+        public int y;
+
+        private ContentLayout(BasicConfigScreen screen) {
+            this.screen = screen;
+            this.centerX = screen.width / 2;
+            this.y = screen.getContentTop();
+            this.areaLeft = (int) (screen.getPanelLeft() + screen.width * 0.1);
+            this.areaRight = (int) (screen.getPanelRight() - screen.width * 0.1);
+            this.contentWidth = areaRight - areaLeft;
+            this.labelWidth = (int) (contentWidth * 0.4f);
+            this.fieldWidth = contentWidth - labelWidth;
+        }
+
+        public BasicConfigScreen screen() {
+            return screen;
+        }
+    }
+
+    protected static class TextLabel extends AbstractWidget {
+        public enum Align {LEFT, CENTER, RIGHT}
+
+        private final Component text;
+        private final int color;
+        private final boolean bold;
+        private final Align align;
+
+        public TextLabel(int x, int y, Component text, Align align, int color, boolean bold) {
+            super(x, y, 0, 0, Component.empty());
+            this.text = text;
+            this.align = align;
+            this.color = color;
+            this.bold = bold;
+        }
+
+        @Override
+        public void renderWidget(GuiGraphics graphics, int mouseX, int mouseY, float partialTick) {
+            var font = Minecraft.getInstance().font;
+            int drawX = this.getX();
+            int textWidth = font.width(text.getString());
+            switch (align) {
+                case CENTER -> drawX = this.getX() - textWidth / 2;
+                case RIGHT -> drawX = this.getX() - textWidth;
+                case LEFT -> drawX = this.getX();
+            }
+
+            if (bold) {
+                graphics.drawString(font, text.copy().withStyle(style -> style.withBold(true)), drawX, this.getY(), color, false);
+            } else {
+                graphics.drawString(font, text, drawX, this.getY(), color, false);
+            }
+        }
+
+        @Override
+        protected void updateWidgetNarration(@NotNull NarrationElementOutput narrationElementOutput) {
+        }
+    }
+
+    protected static class ScrollEntry {
+        final AbstractWidget widget;
+        final int baseY;
+
+        ScrollEntry(AbstractWidget widget, int baseY) {
+            this.widget = widget;
+            this.baseY = baseY;
+        }
+
+        void applyScroll(int offset) {
+            widget.setY(baseY + offset);
+        }
+    }
+}

--- a/common/src/main/java/com/fangsu/ui/ObjBlockConfigScreen.java
+++ b/common/src/main/java/com/fangsu/ui/ObjBlockConfigScreen.java
@@ -1,54 +1,32 @@
 package com.fangsu.ui;
 
-import com.fangsu.Main;
 import com.fangsu.blockEntities.BaseObjBlockEntity;
 import com.fangsu.customItem.CustomItems;
 import com.fangsu.customItem.SubModelDispInfo;
-import com.fangsu.extraConfig.*;
+import com.fangsu.extraConfig.ConfigEntry;
+import com.fangsu.extraConfig.ConfigWidget;
 import net.minecraft.client.Minecraft;
-import net.minecraft.client.gui.GuiGraphics;
-import net.minecraft.client.gui.components.*;
-import net.minecraft.client.gui.narration.NarrationElementOutput;
-import net.minecraft.client.gui.screens.Screen;
+import net.minecraft.client.gui.components.Button;
 import net.minecraft.network.chat.Component;
-import net.minecraft.util.Mth;
-import org.jetbrains.annotations.NotNull;
 
-import java.util.ArrayList;
 import java.util.List;
-import java.util.function.Consumer;
 
-public class ObjBlockConfigScreen extends Screen {
+public class ObjBlockConfigScreen extends BasicConfigScreen {
 
-    // 切换：true -> 实时每次滑动调用 sendUpdateC2S()
-    //      false -> 只在 onClose() 时调用一次 sendUpdateC2S()
     private static final boolean REALTIME = false;
 
     private final BaseObjBlockEntity be;
 
-    // 保存 BE 的数值本地副本（避免直接频繁访问 be）
     private float translateX, translateY, translateZ;
     private float rotateX, rotateY, rotateZ;
 
-    // 可滚动区域偏移（向上为正）
-    private int scrollOffset = 0;
-
-    // 存放所有动态创建的控件，便于在滚动时调整位置
-    private Button closeButton;
-    private final List<AbstractWidget> fixedWidgets = new ArrayList<>();
-    private final List<ScrollEntry> entries = new ArrayList<>();
-
     private final List<ConfigEntry<?>> configs;
     private boolean useSliderInput = true;
-    private boolean pendingRebuild = false;
-
-    private boolean firstBuild = true;
 
     public ObjBlockConfigScreen(BaseObjBlockEntity be) {
         super(Component.translatable("ui.fangsu.block.title"));
         this.be = be;
 
-        // 从 BE 读取初始值（防空）
         if (be != null) {
             this.translateX = be.translateX;
             this.translateY = be.translateY;
@@ -58,7 +36,6 @@ public class ObjBlockConfigScreen extends Screen {
             this.rotateZ = be.rotateZ;
             this.configs = be.getConfigs();
         } else {
-            // 默认值（若 BE 为 null）
             this.translateX = this.translateY = this.translateZ = 0f;
             this.rotateX = this.rotateY = this.rotateZ = 0f;
             this.configs = List.of();
@@ -66,45 +43,38 @@ public class ObjBlockConfigScreen extends Screen {
     }
 
     @Override
-    protected void init() {
-        super.init();
-        entries.clear();
-        fixedWidgets.clear();
-//        scrollOffset = 0;
-
-        // 计算布局基准
-        int cx = this.width / 2;
-        int startY = getContentTop(); // 首行基线
-        int spacing = 70;
-        int y = startY;
-
-        int areaLeft = (int) (getPanelLeft() + this.width * 0.1);
-        int areaRight = (int) (getPanelRight() - this.width * 0.1);
-        int contentWidth = areaRight - areaLeft;
-        int labelW = (int) (contentWidth * 0.4f);
-        int fieldW = contentWidth - labelW;
-
-        int leftX = areaLeft;
-
+    protected void buildFixedWidgets() {
         Button toggleInputButton = Button.builder(getInputToggleLabel(), btn -> {
             useSliderInput = !useSliderInput;
             requestRebuild();
         }).bounds(this.width - 170, 34, 130, 20).build();
         addFixedWidget(toggleInputButton);
 
+        closeButton = addFixedWidget(Button.builder(Component.translatable("ui.fangsu.block.close_and_save"), btn -> {
+            if (!REALTIME) sendToServer();
+            onClose();
+        }).bounds(this.width / 2 - 50, this.height - 40, 100, 20).build());
+    }
 
-        addEntry(createTextLabel(cx, y, Component.translatable("ui.fangsu.block.modelSelect"), TextLabel.Align.CENTER, 0xFFFFFF, false), y);
+    @Override
+    protected void buildScrollableContent(ContentLayout layout) {
+        int spacing = 70;
+        int y = layout.y;
+        if (be == null) {
+            addEntry(createTextLabel(layout.centerX, y, Component.literal("No block entity"), TextLabel.Align.CENTER, 0xFFFFFF, false), y);
+            return;
+        }
+
+        addEntry(createTextLabel(layout.centerX, y, Component.translatable("ui.fangsu.block.modelSelect"), TextLabel.Align.CENTER, 0xFFFFFF, false), y);
         y += 12;
-        addEntry(addButton(areaLeft, y, areaRight - areaLeft, 24, Component.translatable("ui.fangsu.block.mainModelSelect"),
-                (b) -> {
-                    Minecraft.getInstance().setScreen(new ModelSelectScreen(
-                            Component.translatable("ui.fangsu.block.mainModelSelect"),
-                            this.be,
-                            CustomItems.items.get(this.be.getMainModelKey()),
-                            (be) -> be.mainModel,
-                            (be, v) -> be.mainModel = v, this
-                    ));
-                }
+        addEntry(addButton(layout.areaLeft, y, layout.areaRight - layout.areaLeft, 24, Component.translatable("ui.fangsu.block.mainModelSelect"),
+                (b) -> Minecraft.getInstance().setScreen(new ModelSelectScreen(
+                        Component.translatable("ui.fangsu.block.mainModelSelect"),
+                        this.be,
+                        CustomItems.items.get(this.be.getMainModelKey()),
+                        (target) -> target.mainModel,
+                        (target, v) -> target.mainModel = v, this
+                ))
         ), y);
         y += 28;
 
@@ -113,77 +83,68 @@ public class ObjBlockConfigScreen extends Screen {
             for (int i = 0; i < infos.size(); i++) {
                 SubModelDispInfo info = infos.get(i);
                 if (i + 1 == infos.size() && i % 2 == 0) {
-                    addEntry(addButton(areaLeft, y, areaRight - areaLeft, 24, info.name(),
-                            (b) -> {
-                                Minecraft.getInstance().setScreen(new ModelSelectScreen(
-                                        info.name(),
-                                        this.be,
-                                        info.infos(),
-                                        info.initialGetter(),
-                                        info.setter(), this
-                                ));
-                            }
+                    addEntry(addButton(layout.areaLeft, y, layout.areaRight - layout.areaLeft, 24, info.name(),
+                            (b) -> Minecraft.getInstance().setScreen(new ModelSelectScreen(
+                                    info.name(), this.be, info.infos(), info.initialGetter(), info.setter(), this
+                            ))
                     ), y);
                     y += 28;
                 } else if (i % 2 == 0) {
-                    addEntry(addButton(areaLeft, y, (areaRight - areaLeft) / 2 - 2, 24, info.name(),
-                            (b) -> {
-                                Minecraft.getInstance().setScreen(new ModelSelectScreen(
-                                        info.name(),
-                                        this.be,
-                                        info.infos(),
-                                        info.initialGetter(),
-                                        info.setter(), this
-                                ));
-                            }
+                    addEntry(addButton(layout.areaLeft, y, (layout.areaRight - layout.areaLeft) / 2 - 2, 24, info.name(),
+                            (b) -> Minecraft.getInstance().setScreen(new ModelSelectScreen(
+                                    info.name(), this.be, info.infos(), info.initialGetter(), info.setter(), this
+                            ))
                     ), y);
                 } else {
-                    addEntry(addButton(areaLeft + ((areaRight - areaLeft) / 2) + 2, y, (areaRight - areaLeft) / 2 - 2, 24, info.name(),
-                            (b) -> {
-                                Minecraft.getInstance().setScreen(new ModelSelectScreen(
-                                        info.name(),
-                                        this.be,
-                                        info.infos(),
-                                        info.initialGetter(),
-                                        info.setter(), this
-                                ));
-                            }
+                    addEntry(addButton(layout.areaLeft + ((layout.areaRight - layout.areaLeft) / 2) + 2, y,
+                            (layout.areaRight - layout.areaLeft) / 2 - 2, 24, info.name(),
+                            (b) -> Minecraft.getInstance().setScreen(new ModelSelectScreen(
+                                    info.name(), this.be, info.infos(), info.initialGetter(), info.setter(), this
+                            ))
                     ), y);
                     y += 28;
                 }
             }
         }
 
-        addEntry(createTextLabel(cx, y, Component.translatable("ui.fangsu.block.translate"), TextLabel.Align.CENTER, 0xFFFFFF, false), y);
+        addEntry(createTextLabel(layout.centerX, y, Component.translatable("ui.fangsu.block.translate"), TextLabel.Align.CENTER, 0xFFFFFF, false), y);
         y += 12;
-        y = addAxisControls(cx, spacing, y,
+        y = addAxisControls(
+                layout.centerX, spacing, y,
                 Component.translatable("ui.fangsu.block.transX"),
                 Component.translatable("ui.fangsu.block.transY"),
                 Component.translatable("ui.fangsu.block.transZ"),
-                translateX,
-                translateY,
-                translateZ,
+                translateX, translateY, translateZ,
                 -1, 1, 0.0625f,
                 v -> translateX = v,
                 v -> translateY = v,
-                v -> translateZ = v);
+                v -> translateZ = v,
+                () -> {
+                    if (REALTIME) sendToServer();
+                },
+                useSliderInput
+        );
         y += 28;
 
-        y = addAxisControls(cx, spacing, y,
+        y = addAxisControls(
+                layout.centerX, spacing, y,
                 Component.translatable("ui.fangsu.block.rotX"),
                 Component.translatable("ui.fangsu.block.rotY"),
                 Component.translatable("ui.fangsu.block.rotZ"),
-                rotateX,
-                rotateY,
-                rotateZ,
+                rotateX, rotateY, rotateZ,
                 -180, 180, 5,
                 v -> rotateX = v,
                 v -> rotateY = v,
-                v -> rotateZ = v);
+                v -> rotateZ = v,
+                () -> {
+                    if (REALTIME) sendToServer();
+                },
+                useSliderInput
+        );
         y += 28;
 
         if (configs != null && !configs.isEmpty()) {
-            addEntry(createTextLabel(cx, y, Component.translatable("ui.fangsu.block.extras"), TextLabel.Align.CENTER, 0xFFFFFF, false), y);
+            addEntry(createTextLabel(layout.centerX, y, Component.translatable("ui.fangsu.block.extras"), TextLabel.Align.CENTER, 0xFFFFFF, false), y);
             y += 12;
             for (ConfigEntry<?> c : configs) {
                 c.load(be);
@@ -197,21 +158,12 @@ public class ObjBlockConfigScreen extends Screen {
                 if (!c.isVisible(be)) {
                     continue;
                 }
-                ConfigWidget w = c.createWidget(leftX, y, labelW, fieldW);
+                ConfigWidget w = c.createWidget(layout.areaLeft, y, layout.labelWidth, layout.fieldWidth);
                 addRenderableWidget(w);
                 addEntry(w, y);
                 y += w.getHeight() + 4;
             }
         }
-
-        closeButton = this.addRenderableWidget(Button.builder(Component.translatable("ui.fangsu.block.close_and_save"),
-                btn -> {
-                    if (!REALTIME) sendToServer();
-                    onClose();
-                }).bounds(this.width / 2 - 50, this.height - 40, 100, 20).build());
-        fixedWidgets.add(closeButton);
-        if (firstBuild) requestRebuild();
-        firstBuild = false;
     }
 
     private Component getInputToggleLabel() {
@@ -220,110 +172,6 @@ public class ObjBlockConfigScreen extends Screen {
                 : "ui.fangsu.block.toggle_slider");
     }
 
-    private void requestRebuild() {
-        pendingRebuild = true;
-    }
-
-    private int addAxisControls(
-            int centerX,
-            int spacing,
-            int baseY,
-            Component labelX,
-            Component labelY,
-            Component labelZ,
-            float valueX,
-            float valueY,
-            float valueZ,
-            float min,
-            float max,
-            float step,
-            Consumer<Float> setX,
-            Consumer<Float> setY,
-            Consumer<Float> setZ
-    ) {
-        if (useSliderInput) {
-            addEntry(createSlider(centerX - spacing, baseY, valueX, v -> {
-                setX.accept(v);
-                if (REALTIME) sendToServer();
-            }, min, max, step), baseY);
-            addEntry(createSlider(centerX, baseY, valueY, v -> {
-                setY.accept(v);
-                if (REALTIME) sendToServer();
-            }, min, max, step), baseY);
-            addEntry(createSlider(centerX + spacing, baseY, valueZ, v -> {
-                setZ.accept(v);
-                if (REALTIME) sendToServer();
-            }, min, max, step), baseY);
-            return baseY;
-        }
-        baseY += 12;
-        addEntry(createAxisInput(centerX - spacing, baseY, labelX, valueX, min, max, step, setX), baseY);
-        addEntry(createAxisInput(centerX, baseY, labelY, valueY, min, max, step, setY), baseY);
-        addEntry(createAxisInput(centerX + spacing, baseY, labelZ, valueZ, min, max, step, setZ), baseY);
-        return baseY;
-    }
-
-    private AbstractWidget createAxisInput(
-            int x,
-            int baseY,
-            Component label,
-            float initialValue,
-            float min,
-            float max,
-            float step,
-            Consumer<Float> setter
-    ) {
-        int width = 60;
-        int height = 20;
-        int labelY = baseY - 10;
-        addEntry(createTextLabel(x, labelY, label, TextLabel.Align.CENTER, 0xFFFFFF, false), labelY);
-        EditBox box = new EditBox(this.font, x - width / 2, baseY, width, height, Component.empty());
-        box.setValue(formatValue(initialValue));
-        box.setResponder(text -> {
-            Float value = parseFloat(text);
-            if (value == null) {
-                return;
-            }
-            float snapped = snap(value, min, max, step);
-            setter.accept(snapped);
-            if (REALTIME) sendToServer();
-        });
-        this.addRenderableWidget(box);
-        return box;
-    }
-
-    /**
-     * 创建带步进的滑块。
-     */
-    private SliderWidget createSlider(int cx, int baseY, float initialValue, Consumer<Float> setter, float min, float max, float step) {
-        SliderWidget slider = new SliderWidget(cx - 30, baseY, 60, 20, Component.empty(), initialValue, min, max, step, setter);
-        this.addRenderableWidget(slider);
-        return slider;
-    }
-
-    private TextLabel createTextLabel(int x, int y, Component text, TextLabel.Align align, int color, boolean bold) {
-        TextLabel label = new TextLabel(x, y, text, align, color, bold);
-        this.addRenderableWidget(label);
-        return label;
-    }
-
-    private void addEntry(AbstractWidget widget, int baseY) {
-        entries.add(new ScrollEntry(widget, baseY));
-    }
-
-    private Button addButton(int x, int y, int width, int height, Component label, Button.OnPress onPress) {
-        Button button = Button.builder(label, onPress).bounds(x, y, width, height).build();
-        addRenderableWidget(button);
-        return button;
-    }
-
-    private Button addFixedWidget(Button button) {
-        addRenderableWidget(button);
-        fixedWidgets.add(button);
-        return button;
-    }
-
-    // 将本地副本的数据写回 BE 并调用 sendUpdateC2S()
     private void sendToServer() {
         if (be == null) return;
         be.translateX = translateX;
@@ -332,215 +180,19 @@ public class ObjBlockConfigScreen extends Screen {
         be.rotateX = rotateX;
         be.rotateY = rotateY;
         be.rotateZ = rotateZ;
-
         be.sendUpdateC2S();
     }
 
     @Override
-    public void render(GuiGraphics graphics, int mouseX, int mouseY, float partialTick) {
-        if (pendingRebuild) {
-            pendingRebuild = false;
-            clearWidgets();
-            init();
-        }
-        renderBackground(graphics);
-
-        int areaLeft = getPanelLeft();
-        int areaTop = getPanelTop();
-        int areaRight = getPanelRight();
-        int areaBottom = getPanelBottom();
-        graphics.fill(areaLeft, areaTop, areaRight, areaBottom, 0xCCFFFFFF); // 半透明白
-
-        // 标题（居中，使用深色文本以便在浅底上清晰显示）
-        String titleText = this.title.getString();
-        int titleX = this.width / 2 - this.font.width(titleText) / 2;
-        int titleY = areaTop - 18;
-        graphics.drawString(this.font, this.title, titleX, titleY, 0x101010, false);
-
-        // 在渲染每一帧之前，给 entries 应用 scrollOffset —— 修改它们的 y 值
-        for (ScrollEntry e : entries) {
-            e.applyScroll(scrollOffset);
-        }
-
-        // 先渲染那些固定控件（例如关闭按钮、开关等）——它们不受内容区剪裁影响
-        for (AbstractWidget fixedWidget : fixedWidgets) {
-            fixedWidget.render(graphics, mouseX, mouseY, partialTick);
-        }
-
-        int scissorX = getContentLeft();
-        int scissorY = getContentTop();
-        int scissorW = getContentRight();
-        int scissorH = getContentBottom();
-        graphics.enableScissor(scissorX, scissorY, scissorW, scissorH);
-
-        // 渲染可滚动条目
-        for (ScrollEntry e : entries) {
-            e.widget.render(graphics, mouseX, mouseY, partialTick);
-        }
-
-        graphics.disableScissor();
-    }
-
-
-    @Override
-    public boolean mouseScrolled(double mouseX, double mouseY, double delta) {
-
-        int visibleTop = getContentTop();
-        int visibleBottom = getContentBottom();
-        int visibleHeight = visibleBottom - visibleTop;
-
-        int contentBottom = getActualContentBottom();
-        int contentTop = entries.isEmpty() ? 0 : entries.get(0).baseY;
-        int contentHeight = contentBottom - contentTop;
-
-        // 如果内容根本没超过可视区域，直接禁止滚动
-        if (contentHeight <= visibleHeight) {
-            scrollOffset = 0;
-            return false;
-        }
-
-        scrollOffset += delta * 12;
-
-        int minOffset = visibleHeight - contentHeight;
-        scrollOffset = Mth.clamp(scrollOffset, minOffset, 0);
-
-        return true;
-    }
-
-    private int getPanelLeft() {
-        return 40;
-    }
-
-    private int getPanelRight() {
-        return this.width - 40;
-    }
-
-    private int getPanelTop() {
-        return 30;
-    }
-
-    private int getPanelBottom() {
-        return this.height - 60;
-    }
-
-    private int getContentPadding() {
-        return 12;
-    }
-
-    private int getContentLeft() {
-        return getPanelLeft() + getContentPadding();
-    }
-
-    private int getContentRight() {
-        return getPanelRight() - getContentPadding();
-    }
-
-    private int getContentTop() {
-        return getPanelTop() + getContentPadding() + 12;
-    }
-
-    private int getContentBottom() {
-        return getPanelBottom() - getContentPadding();
-    }
-
-    private int getActualContentBottom() {
-        int bottom = 0;
-        for (ScrollEntry e : entries) {
-            bottom = Math.max(bottom, e.baseY + e.widget.getHeight());
-        }
-        return bottom;
-    }
-
-    private Float parseFloat(String text) {
-        try {
-            return Float.parseFloat(text);
-        } catch (NumberFormatException ex) {
-            return null;
-        }
-    }
-
-    private float snap(float value, float min, float max, float step) {
-        float clamped = Mth.clamp(value, min, max);
-        if (step <= 0) {
-            return clamped;
-        }
-        return Math.round(clamped / step) * step;
-    }
-
-    private String formatValue(float value) {
-        return String.format("%.3f", value);
-    }
-
-
-    @Override
     public void onClose() {
         if (be != null) {
-            if (configs != null)
+            if (configs != null) {
                 for (ConfigEntry<?> c : configs) {
                     c.save(be);
                 }
+            }
             be.sendUpdateC2S();
         }
         super.onClose();
     }
-
-
-    private static class TextLabel extends AbstractWidget {
-        public enum Align {LEFT, CENTER, RIGHT}
-
-        private final Component text;
-        private final int color;
-        private final boolean bold;
-        private final Align align;
-
-        public TextLabel(int x, int y, Component text, Align align, int color, boolean bold) {
-            super(x, y, 0, 0, Component.empty());
-            this.text = text;
-            this.align = align;
-            this.color = color;
-            this.bold = bold;
-        }
-
-        @Override
-        public void renderWidget(GuiGraphics graphics, int mouseX, int mouseY, float partialTick) {
-            var font = Minecraft.getInstance().font;
-            int drawX = this.getX();
-
-            // 根据对齐方式调整 x
-            String labelText = text.getString();
-            int textWidth = font.width(labelText);
-            switch (align) {
-                case CENTER -> drawX = this.getX() - textWidth / 2;
-                case RIGHT -> drawX = this.getX() - textWidth;
-                case LEFT -> drawX = this.getX();
-            }
-
-            // 绘制文本，可加粗
-            if (bold) {
-                graphics.drawString(font, text.copy().withStyle(style -> style.withBold(true)), drawX, this.getY(), color, false);
-            } else {
-                graphics.drawString(font, text, drawX, this.getY(), color, false);
-            }
-        }
-
-        @Override
-        protected void updateWidgetNarration(@NotNull NarrationElementOutput narrationElementOutput) {
-        }
-    }
-
-
-    private static class ScrollEntry {
-        final AbstractWidget widget;
-        final int baseY;
-
-        ScrollEntry(AbstractWidget widget, int baseY) {
-            this.widget = widget;
-            this.baseY = baseY;
-        }
-
-        void applyScroll(int offset) {
-            widget.setY(baseY + offset);
-        }
-    }
-
 }

--- a/common/src/main/java/com/fangsu/ui/SignConfigUI.java
+++ b/common/src/main/java/com/fangsu/ui/SignConfigUI.java
@@ -1,0 +1,453 @@
+package com.fangsu.ui;
+
+import com.fangsu.Main;
+import com.fangsu.blockEntities.BaseObjBlockEntity;
+import com.fangsu.signItems.SignDrawContext;
+import com.fangsu.signItems.SignItem;
+import com.fangsu.signItems.SignItemFactory;
+import com.fangsu.utils.ResourceUtil;
+import com.google.gson.*;
+import net.minecraft.client.gui.GuiGraphics;
+import net.minecraft.client.gui.screens.Screen;
+import net.minecraft.network.chat.Component;
+import net.minecraft.resources.ResourceLocation;
+import org.jetbrains.annotations.Nullable;
+
+import java.util.*;
+
+/**
+ * 参考 signsc.js 的双阶段结构：
+ * 1) 选择 front/back + left/middle/right 的 6 行；
+ * 2) 编辑某一行的元素，并从 signItems 面板插入新元素。
+ */
+public class SignConfigUI extends Screen {
+
+    private static final Gson GSON = new Gson();
+    private static final int ROW_COUNT = 6;
+
+    private final BaseObjBlockEntity blockEntity;
+    private final Map<String, List<List<JsonObject>>> displayState = new HashMap<>();
+    private final List<JsonObject> signItems = new ArrayList<>();
+
+    private int modeFlag = 0;
+    private int selectedRow = -1;
+    private int sideEditing = -1;
+    private float[] rowScroll = new float[ROW_COUNT];
+    private float paletteScroll = 0;
+
+    public SignConfigUI(BaseObjBlockEntity blockEntity) {
+        super(Component.translatable("ui.fangsu.sign.title"));
+        this.blockEntity = blockEntity;
+        initDisplayState();
+        loadSignItems();
+    }
+
+    @Override
+    protected void init() {
+        super.init();
+        if (rowScroll.length != ROW_COUNT) {
+            rowScroll = new float[ROW_COUNT];
+        }
+    }
+
+    @Override
+    public void render(GuiGraphics graphics, int mouseX, int mouseY, float partialTick) {
+        renderBackground(graphics);
+        graphics.fill(0, 0, width, height, 0xFF101010);
+
+        if (modeFlag == 0) {
+            drawSelectionScreen(graphics, mouseX, mouseY);
+        } else {
+            drawEditingScreen(graphics, mouseX, mouseY);
+        }
+
+        graphics.drawString(font, this.title, 10, 10, 0xFFFFFF, false);
+    }
+
+    private void drawSelectionScreen(GuiGraphics graphics, int mouseX, int mouseY) {
+        int i = 0;
+        int rowHeight = Math.max(40, (int) (height * 0.14f));
+        for (String side : List.of("front", "back")) {
+            for (int part = 0; part < 3; part++) {
+                int rowY = 40 + i * rowHeight;
+                int rowBottom = rowY + rowHeight - 4;
+                boolean selected = mouseY >= rowY && mouseY <= rowBottom;
+
+                graphics.fill(12, rowY, width - 12, rowBottom, selected ? 0x55222222 : 0x441A1A1A);
+                graphics.drawString(font, side + " - " + partName(part), 16, rowY + 6, 0xFFFFFF, false);
+
+                List<JsonObject> lane = displayState.get(side).get(part);
+                drawLane(graphics, lane, 18 + rowScroll[i], rowY + 18, part == 2 ? 2 : part, 18f);
+                i++;
+            }
+        }
+    }
+
+    private void drawEditingScreen(GuiGraphics graphics, int mouseX, int mouseY) {
+        LaneRef laneRef = rowIndexToLane(selectedRow);
+        if (laneRef == null) {
+            modeFlag = 0;
+            return;
+        }
+
+        List<JsonObject> lane = laneRef.lane();
+        graphics.fill(12, 36, width - 12, 92, 0x441E1E1E);
+        graphics.drawString(font, Component.translatable("ui.fangsu.sign.editing").getString() + " " + laneRef.face() + " - " + partName(laneRef.part()), 16, 44, 0xFFFFFF, false);
+        graphics.drawString(font, "ESC: back", width - 70, 44, 0xCCCCCC, false);
+
+        float x = 24;
+        float y = 62;
+        float u = 24;
+
+        if (lane.isEmpty()) {
+            drawPlus(graphics, x, y, u);
+        }
+
+        for (int idx = 0; idx < lane.size(); idx++) {
+            JsonObject token = lane.get(idx);
+            float tokenW = getTokenWidth(graphics, token, u, laneRef.part());
+            boolean hover = mouseX >= x && mouseX <= x + tokenW && mouseY >= y && mouseY <= y + u;
+
+            if (hover) {
+                graphics.fill((int) x, (int) y, (int) (x + tokenW), (int) (y + u), 0x33FFFFFF);
+                graphics.drawString(font, "L:edit R:del", (int) x, (int) (y - 10), 0xE0E0E0, false);
+            }
+
+            drawToken(graphics, token, x, y, u, laneRef.part());
+
+            boolean addHover = mouseX >= x + tokenW && mouseX <= x + tokenW + u / 2f && mouseY >= y && mouseY <= y + u;
+            if (addHover || sideEditing == idx) {
+                drawPlus(graphics, x + tokenW, y, u / 2f);
+            }
+
+            x += tokenW + (u * 0.35f);
+        }
+
+        drawPalette(graphics, mouseX, mouseY, laneRef, lane);
+    }
+
+    private void drawPalette(GuiGraphics graphics, int mouseX, int mouseY, LaneRef laneRef, List<JsonObject> lane) {
+        int top = 110;
+        int lineItems = Math.max(1, (width - 24) / 30);
+        int cell = 24;
+        int gap = 4;
+
+        graphics.enableScissor(12, top, width - 12, height - 12);
+        for (int idx = 0; idx < signItems.size(); idx++) {
+            int row = idx / lineItems;
+            int col = idx % lineItems;
+            int x = 16 + col * (cell + gap);
+            int y = top + (int) paletteScroll + row * (cell + gap);
+            boolean hover = mouseX >= x && mouseX <= x + cell && mouseY >= y && mouseY <= y + cell;
+
+            graphics.fill(x, y, x + cell, y + cell, hover ? 0x33FFFFFF : 0x22000000);
+            JsonObject token = signItems.get(idx);
+            drawToken(graphics, token, x + 2, y + 2, cell - 4, laneRef.part());
+            if (hover) {
+                graphics.drawString(font, "+", x + 9, y + 8, 0xFFFFFF, false);
+            }
+        }
+        graphics.disableScissor();
+    }
+
+    private void drawLane(GuiGraphics graphics, List<JsonObject> lane, float startX, float y, int align, float u) {
+        float x = startX;
+        if (align == 2) {
+            x = width - 20 + startX;
+        }
+        for (JsonObject token : lane) {
+            float tokenWidth = getTokenWidth(graphics, token, u, align);
+            drawToken(graphics, token, x, y, u, align);
+            x += (align == 2 ? -1 : 1) * (tokenWidth + u * 0.1f);
+        }
+    }
+
+    private float getTokenWidth(GuiGraphics graphics, JsonObject token, float unit, int align) {
+        String type = token.get("type").getAsString();
+        if (SignItemFactory.has(type)) {
+            SignItem item = SignItemFactory.get(type);
+            return Math.max(unit * 0.5f, item.getWidth(new SignDrawContext(graphics, 0, 0, unit, align, token.get("content"))));
+        }
+        if ("space".equals(type)) {
+            return unit * token.getAsJsonObject("content").get("width").getAsFloat();
+        }
+        if ("str".equals(type)) {
+            String text = token.getAsJsonObject("content").get("text").getAsString();
+            return Math.max(unit * 0.6f, font.width(text.replace('|', ' ')) * (unit / 18f));
+        }
+        return unit;
+    }
+
+
+    private float getTokenWidthForHit(JsonObject token, float unit, int align) {
+        String type = token.has("type") ? token.get("type").getAsString() : "";
+        if ("space".equals(type) && token.has("content") && token.getAsJsonObject("content").has("width")) {
+            return unit * token.getAsJsonObject("content").get("width").getAsFloat();
+        }
+        if ("str".equals(type) && token.has("content") && token.getAsJsonObject("content").has("text")) {
+            String text = token.getAsJsonObject("content").get("text").getAsString();
+            return Math.max(unit * 0.6f, font.width(text.replace('|', ' ')) * (unit / 18f));
+        }
+        if (SignItemFactory.has(type)) {
+            return unit;
+        }
+        return unit;
+    }
+    private void drawToken(GuiGraphics graphics, JsonObject token, float x, float y, float unit, int align) {
+        String type = token.get("type").getAsString();
+        JsonObject content = token.getAsJsonObject("content");
+
+        if (SignItemFactory.has(type)) {
+            SignItemFactory.get(type).draw(new SignDrawContext(graphics, x, y, unit, align, content));
+            return;
+        }
+
+        if ("str".equals(type)) {
+            String text = content.has("text") ? content.get("text").getAsString() : "";
+            graphics.drawString(font, text.replace('|', ' '), (int) x, (int) y + 8, 0xFFFFFF, false);
+        } else if ("space".equals(type)) {
+            graphics.fill((int) x, (int) y + (int) (unit / 2), (int) (x + unit), (int) (y + unit / 2 + 1), 0x66AAAAAA);
+        } else {
+            String icon = token.has("icon") ? token.get("icon").getAsString() : "?";
+            graphics.fill((int) x, (int) y, (int) (x + unit), (int) (y + unit), 0x55181818);
+            graphics.drawString(font, icon.contains(":") ? icon.substring(icon.indexOf(':') + 1).replace(".png", "") : icon,
+                    (int) x + 1, (int) y + 8, 0xFFEFEFEF, false);
+        }
+    }
+
+    private void drawPlus(GuiGraphics graphics, float x, float y, float size) {
+        int cx = (int) (x + size / 2f);
+        int cy = (int) (y + size / 2f);
+        graphics.fill(cx - 1, (int) y + 2, cx + 1, (int) (y + size - 2), 0xFFFFFFFF);
+        graphics.fill((int) x + 2, cy - 1, (int) (x + size - 2), cy + 1, 0xFFFFFFFF);
+    }
+
+    @Override
+    public boolean mouseClicked(double mouseX, double mouseY, int button) {
+        if (modeFlag == 0) {
+            int rowHeight = Math.max(40, (int) (height * 0.14f));
+            for (int i = 0; i < ROW_COUNT; i++) {
+                int rowY = 40 + i * rowHeight;
+                if (mouseY >= rowY && mouseY <= rowY + rowHeight - 4) {
+                    selectedRow = i;
+                    modeFlag = 1;
+                    return true;
+                }
+            }
+            return super.mouseClicked(mouseX, mouseY, button);
+        }
+
+        LaneRef laneRef = rowIndexToLane(selectedRow);
+        if (laneRef == null) return super.mouseClicked(mouseX, mouseY, button);
+        List<JsonObject> lane = laneRef.lane();
+
+        float x = 24;
+        float y = 62;
+        float u = 24;
+        for (int idx = 0; idx < lane.size(); idx++) {
+            JsonObject token = lane.get(idx);
+            float tokenW = getTokenWidthForHit(token, u, laneRef.part());
+            if (mouseX >= x && mouseX <= x + tokenW && mouseY >= y && mouseY <= y + u) {
+                if (button == 1) {
+                    lane.remove(idx);
+                    persistDisplay();
+                    return true;
+                }
+                if (token.has("content") && token.getAsJsonObject("content").has("duiqi")) {
+                    JsonObject content = token.getAsJsonObject("content");
+                    int current = content.get("duiqi").getAsInt();
+                    content.addProperty("duiqi", (current + 1) % 3);
+                    persistDisplay();
+                }
+                return true;
+            }
+            boolean addHover = mouseX >= x + tokenW && mouseX <= x + tokenW + u / 2f && mouseY >= y && mouseY <= y + u;
+            if (addHover) {
+                sideEditing = idx;
+                return true;
+            }
+            x += tokenW + (u * 0.35f);
+        }
+
+        int top = 110;
+        int lineItems = Math.max(1, (width - 24) / 30);
+        int cell = 24;
+        int gap = 4;
+        for (int idx = 0; idx < signItems.size(); idx++) {
+            int row = idx / lineItems;
+            int col = idx % lineItems;
+            int px = 16 + col * (cell + gap);
+            int py = top + (int) paletteScroll + row * (cell + gap);
+            if (mouseX >= px && mouseX <= px + cell && mouseY >= py && mouseY <= py + cell) {
+                if (sideEditing < 0) {
+                    sideEditing = lane.size() - 1;
+                }
+                lane.add(Math.min(sideEditing + 1, lane.size()), deepCopy(signItems.get(idx)));
+                sideEditing = -1;
+                persistDisplay();
+                return true;
+            }
+        }
+
+        return super.mouseClicked(mouseX, mouseY, button);
+    }
+
+    @Override
+    public boolean mouseScrolled(double mouseX, double mouseY, double delta) {
+        if (modeFlag == 0) {
+            int rowHeight = Math.max(40, (int) (height * 0.14f));
+            for (int i = 0; i < ROW_COUNT; i++) {
+                int rowY = 40 + i * rowHeight;
+                if (mouseY >= rowY && mouseY <= rowY + rowHeight - 4) {
+                    rowScroll[i] += (float) (delta * 8f);
+                    return true;
+                }
+            }
+            return super.mouseScrolled(mouseX, mouseY, delta);
+        }
+
+        if (mouseY >= 110) {
+            paletteScroll += (float) (delta * 10f);
+            float min = -Math.max(0, (float) Math.ceil((double) signItems.size() / Math.max(1, (width - 24) / 30)) * 28f - (height - 122));
+            paletteScroll = Math.max(min, Math.min(0, paletteScroll));
+            return true;
+        }
+        return super.mouseScrolled(mouseX, mouseY, delta);
+    }
+
+    @Override
+    public boolean keyPressed(int keyCode, int scanCode, int modifiers) {
+        if (keyCode == 256 && modeFlag == 1) {
+            modeFlag = 0;
+            selectedRow = -1;
+            sideEditing = -1;
+            return true;
+        }
+        return super.keyPressed(keyCode, scanCode, modifiers);
+    }
+
+    @Override
+    public void onClose() {
+        persistDisplay();
+        super.onClose();
+    }
+
+    private void initDisplayState() {
+        displayState.put("front", new ArrayList<>(List.of(new ArrayList<>(), new ArrayList<>(), new ArrayList<>())));
+        displayState.put("back", new ArrayList<>(List.of(new ArrayList<>(), new ArrayList<>(), new ArrayList<>())));
+
+        String raw = blockEntity.getExtraConfig("dispItems");
+        if (raw == null || raw.isBlank()) {
+            return;
+        }
+        try {
+            JsonObject obj = JsonParser.parseString(raw).getAsJsonObject();
+            loadFace(obj, "front");
+            loadFace(obj, "back");
+        } catch (Exception e) {
+            Main.LOGGER.warn("Failed to parse dispItems: {}", e.getMessage());
+        }
+    }
+
+    private void loadFace(JsonObject src, String face) {
+        if (!src.has(face) || !src.get(face).isJsonArray()) {
+            return;
+        }
+        JsonArray faceArr = src.getAsJsonArray(face);
+        for (int i = 0; i < 3 && i < faceArr.size(); i++) {
+            JsonElement laneElem = faceArr.get(i);
+            if (!laneElem.isJsonArray()) continue;
+            List<JsonObject> lane = displayState.get(face).get(i);
+            for (JsonElement token : laneElem.getAsJsonArray()) {
+                if (token.isJsonObject()) {
+                    lane.add(token.getAsJsonObject());
+                }
+            }
+        }
+    }
+
+    private void loadSignItems() {
+        signItems.clear();
+        ResourceLocation builtin = new ResourceLocation("fangsu:sign/builtinsign.json");
+        try {
+            JsonObject obj = JsonParser.parseString(ResourceUtil.loadString(builtin)).getAsJsonObject();
+            if (obj != null && obj.has("signItems") && obj.get("signItems").isJsonArray()) {
+                for (JsonElement element : obj.getAsJsonArray("signItems")) {
+                    if (element.isJsonObject()) signItems.add(element.getAsJsonObject());
+                }
+            }
+        } catch (Exception e) {
+            Main.LOGGER.warn("Failed to load builtinsign.json: {}", e.getMessage());
+        }
+
+        for (SignItem signItem : registeredSignItems()) {
+            JsonObject obj = new JsonObject();
+            obj.addProperty("type", signItem.getType());
+            try {
+                if (signItem.getIcon() != null) {
+                    obj.addProperty("icon", "mtrsteamloco:imgnotfound.png");
+                }
+            } catch (Exception ignored) {
+            }
+            obj.add("content", new JsonObject());
+            signItems.add(obj);
+        }
+    }
+
+    private List<SignItem> registeredSignItems() {
+        List<SignItem> result = new ArrayList<>();
+        for (String type : List.of("str", "img", "route", "routeb", "trainicon", "destination", "space")) {
+            if (SignItemFactory.has(type)) {
+                try {
+                    result.add(SignItemFactory.get(type));
+                } catch (Exception ignored) {
+                }
+            }
+        }
+        return result;
+    }
+
+    private void persistDisplay() {
+        JsonObject root = new JsonObject();
+        root.add("front", exportFace("front"));
+        root.add("back", exportFace("back"));
+        blockEntity.setExtraConfig("dispItems", GSON.toJson(root));
+        blockEntity.sendUpdateC2S();
+    }
+
+    private JsonArray exportFace(String face) {
+        JsonArray arr = new JsonArray();
+        for (List<JsonObject> lane : displayState.get(face)) {
+            JsonArray laneArr = new JsonArray();
+            for (JsonObject token : lane) {
+                laneArr.add(token);
+            }
+            arr.add(laneArr);
+        }
+        return arr;
+    }
+
+    @Nullable
+    private LaneRef rowIndexToLane(int index) {
+        if (index < 0 || index >= ROW_COUNT) return null;
+        String face = index < 3 ? "front" : "back";
+        int part = index % 3;
+        return new LaneRef(face, part, displayState.get(face).get(part));
+    }
+
+    private String partName(int part) {
+        return switch (part) {
+            case 0 -> "left";
+            case 1 -> "middle";
+            case 2 -> "right";
+            default -> "unknown";
+        };
+    }
+
+    private JsonObject deepCopy(JsonObject input) {
+        return JsonParser.parseString(input.toString()).getAsJsonObject();
+    }
+
+    private record LaneRef(String face, int part, List<JsonObject> lane) {
+    }
+}

--- a/common/src/main/resources/assets/fangsu/lang/en_us.json
+++ b/common/src/main/resources/assets/fangsu/lang/en_us.json
@@ -34,5 +34,7 @@
   "msg.fangsu.ticketbarrier.fareOnce": "Deducted %s | Balance: %s",
   "tab.fangsu.main": "FangSu · Core",
   "block.fangsu.ticket_barrier": "Ticket Barrier",
-  "block.fangsu.collision_compensation_block": "Collision Compensation Block"
+  "block.fangsu.collision_compensation_block": "Collision Compensation Block",
+  "ui.fangsu.sign.title": "Sign Configuration",
+  "ui.fangsu.sign.editing": "Editing"
 }

--- a/common/src/main/resources/assets/fangsu/lang/zh_cn.json
+++ b/common/src/main/resources/assets/fangsu/lang/zh_cn.json
@@ -38,5 +38,7 @@
   "block.fangsu.ticket_barrier": "检票闸机",
   "block.fangsu.screendoor_door": "屏蔽门 (门)",
   "block.fangsu.screendoor_glass": "屏蔽门 (玻璃)",
-  "block.fangsu.collision_compensation_block": "碰撞箱补偿方块"
+  "block.fangsu.collision_compensation_block": "碰撞箱补偿方块",
+  "ui.fangsu.sign.title": "标识牌配置",
+  "ui.fangsu.sign.editing": "正在编辑"
 }


### PR DESCRIPTION
### Motivation
- Reduce duplication by extracting common config-screen UI behavior into a reusable base and implement an interactive sign editor ported from the original JS logic.

### Description
- Add `BasicConfigScreen` which centralizes panel layout, scrollable entries, fixed widgets, rebuild flow, axis input helpers (slider / edit box), and common rendering utilities.
- Convert `ObjBlockConfigScreen` to subclass `BasicConfigScreen`, moving shared plumbing to the base while keeping model selection, transform editing and extra-config handling intact.
- Add `SignConfigUI` that implements the two-stage sign editor (select front/back × left/middle/right, edit a lane, insert/delete tokens, palette scrolling) and integrates with `SignItemFactory`/`SignItem` for custom sign item rendering and width computation, persisting configuration via the block entity `dispItems` extra config.
- Add i18n entries for the sign UI (`ui.fangsu.sign.title`, `ui.fangsu.sign.editing`) in both `en_us.json` and `zh_cn.json`.

### Testing
- Ran `git diff --check` to validate repository whitespace/format issues and it passed with no reported problems.
- Attempted to run `./gradlew :common:compileJava` but the Gradle wrapper download was blocked by the environment proxy (HTTP 403), so a full compile could not be completed in this environment.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_698bf5995e90832ea3597c2273668277)