### PR TITLE
Improve SignConfigUI rendering, scrolling and UnknownItem placeholder

### DIFF
--- a/common/src/main/java/com/fangsu/signItems/UnknownItem.java
+++ b/common/src/main/java/com/fangsu/signItems/UnknownItem.java
@@ -30,16 +30,19 @@ public class UnknownItem extends SignItem {
     @Override
     public void draw(SignDrawContext ctx) {
         Graphics2D g = ctx.graphics();
-        int x = (int) ctx.x();
-        int y = (int) ctx.y();
-        int align = ctx.align();
-        int u = (int) ctx.unit();
-        int baseX = x + (align == 2 ? -u : 0);
-        g.setColor(Color.black);
-        g.fillRect(baseX, y, u, u);
-        g.setColor(new Color(255, 100, 100));
-        g.fillRect(baseX, y, u / 2, u / 2);
-        g.fillRect(baseX + u / 2, y + u / 2, u, u);
+        int x = Math.round(ctx.x());
+        int y = Math.round(ctx.y());
+        int u = Math.round(ctx.unit());
+        g.setColor(new Color(34, 34, 34));
+        g.fillRect(x, y, u, u);
+        int bar = Math.max(2, u / 5);
+        g.setColor(new Color(220, 60, 60));
+        g.fillRect(x, y, u, bar);
+        g.fillRect(x, y + u - bar, u, bar);
+        g.fillRect(x, y, bar, u);
+        g.fillRect(x + u - bar, y, bar, u);
+        g.setColor(new Color(255, 180, 180));
+        g.fillRect(x + bar, y + bar, Math.max(1, u - bar * 2), Math.max(1, u - bar * 2));
     }
 
     @Override

--- a/common/src/main/java/com/fangsu/ui/SignConfigUI.java
+++ b/common/src/main/java/com/fangsu/ui/SignConfigUI.java
@@ -21,6 +21,7 @@ import static com.fangsu.signItems.SignItemFactory.EDITOR_ITEMS;
 public class SignConfigUI extends Screen {
 
     private static final int ROW_COUNT = 6;
+    private static final int G2D_SCALE = 2;
 
     private List<Map<String, List<SignItem>>> dispItems;
     private final Consumer<List<Map<String, List<SignItem>>>> setter;
@@ -31,6 +32,7 @@ public class SignConfigUI extends Screen {
     private int sideEditing = -1; // -2 = head insert
     private float[] rowScroll = new float[ROW_COUNT];
     private float paletteScroll = 0;
+    private float editingPreviewScroll = 0;
     private int faces = 2;
 
     private GraphicsTexture g2dLayer;
@@ -86,14 +88,14 @@ public class SignConfigUI extends Screen {
         if (g2dLayer != null) g2dLayer.close();
         int texW = Math.max(1, width);
         int texH = Math.max(1, height);
-        g2dLayer = new GraphicsTexture(texW, texH);
+        g2dLayer = new GraphicsTexture(texW * G2D_SCALE, texH * G2D_SCALE);
         g2dLayer.graphics.setRenderingHint(RenderingHints.KEY_ANTIALIASING, RenderingHints.VALUE_ANTIALIAS_ON);
     }
 
     private void drawSelectionScreen(GuiGraphics graphics, int mouseX, int mouseY) {
         int rowHeight = (height - 12) / ROW_COUNT;
         int i = 0;
-        float u = (rowHeight / 7f) * 6f;
+        float u = Math.min(30f, rowHeight * 0.5f);
         Graphics2D g2d = g2dLayer.graphics;
 
         for (int side = 0; side < faces; side++) {
@@ -116,6 +118,7 @@ public class SignConfigUI extends Screen {
                     modeFlag = 1;
                     inEditingRow = new LaneRef(side, part, lane);
                     paletteScroll = 0;
+                    editingPreviewScroll = 0;
                     sideEditing = lane.isEmpty() ? -2 : -1;
                 }
                 i++;
@@ -147,12 +150,15 @@ public class SignConfigUI extends Screen {
         float totalWidth = 0;
         for (SignItem token : lane) totalWidth += getTokenWidth(g2dLayer.graphics, token, u) + u * 0.35f;
 
-        float x;
-        switch (laneRef.part()) {
-            case 2 -> x = width - 24 - totalWidth;
-            case 1 -> x = (width - totalWidth) / 2f;
-            default -> x = 24;
-        }
+        float baseX = switch (laneRef.part()) {
+            case 2 -> width - 24 - totalWidth;
+            case 1 -> (width - totalWidth) / 2f;
+            default -> 24;
+        };
+        float minPreviewScroll = Math.min(0, width - 24 - (baseX + totalWidth));
+        float maxPreviewScroll = Math.max(0, 24 - baseX);
+        editingPreviewScroll = Math.max(minPreviewScroll, Math.min(maxPreviewScroll, editingPreviewScroll));
+        float x = baseX + editingPreviewScroll;
 
         boolean blink = (System.currentTimeMillis() / 400) % 2 == 0;
         float headIndicatorX = x - u * 0.25f;
@@ -177,7 +183,7 @@ public class SignConfigUI extends Screen {
             boolean hover = mouseX >= x && mouseX <= x + tokenW && mouseY >= y && mouseY <= y + u;
             if (hover) {
                 graphics.fill((int) x, (int) y, (int) (x + tokenW), (int) (y + u), 0x33FFFFFF);
-                graphics.drawString(font, "L:edit  R:del", (int) x, (int) (y - 10), 0xE0E0E0, false);
+                graphics.drawString(font, Component.translatable("ui.fangsu.sign.edit_hint"), (int) x, (int) (y - 10), 0xE0E0E0, false);
             }
 
             if (mouseClickInfo != null && hover) {
@@ -215,8 +221,8 @@ public class SignConfigUI extends Screen {
 
         LayoutItem layoutItem = layoutEditRef.layoutItem;
         graphics.fill(12, 24, width - 12, 140, 0x441E1E1E);
-        graphics.drawString(font, Component.literal("MultiLine Layout"), 16, 32, 0xFFFFFF, false);
-        graphics.drawString(font, Component.literal("左键编辑，右键删除，点击上/下槽切换"), 16, 45, 0xCCCCCC, false);
+        graphics.drawString(font, Component.translatable("ui.fangsu.sign.layout_title"), 16, 32, 0xFFFFFF, false);
+        graphics.drawString(font, Component.translatable("ui.fangsu.sign.layout_hint"), 16, 45, 0xCCCCCC, false);
 
         int boxX = 20;
         int boxW = width - 40;
@@ -294,6 +300,9 @@ public class SignConfigUI extends Screen {
             SignItem token = EDITOR_ITEMS.get(idx);
             graphics.blit(token.getIconLocation(), x + 3, y + 3, 0, 0, cell - 6, cell - 6, cell - 6, cell - 6);
             if (hover) graphics.drawString(font, "+", x + cell / 2 - 3, y + cell / 2 - 4, 0xFFFFFF, false);
+            if (hover) {
+                graphics.renderTooltip(font, Component.translatable("ui.fangsu.sign.item." + token.getType()), mouseX, mouseY);
+            }
 
             if (hover && mouseClickInfo != null && (mouseClickInfo.button == 0 || mouseClickInfo.button == 1 || mouseClickInfo.button == 2)) {
                 SignItem newItem = copySignItem(token);
@@ -401,6 +410,10 @@ public class SignConfigUI extends Screen {
                 }
             }
         } else {
+            if (modeFlag == 1 && mouseY >= 24 && mouseY <= 78) {
+                editingPreviewScroll += (float) (delta * 10f);
+                return true;
+            }
             if (mouseY >= 170) {
                 paletteScroll += (float) (delta * 10f);
                 return true;
@@ -421,6 +434,7 @@ public class SignConfigUI extends Screen {
             if (modeFlag < 0) onClose();
             else if (modeFlag == 0) {
                 inEditingRow = null;
+                editingPreviewScroll = 0;
                 sideEditing = -1;
             }
             return true;
@@ -435,6 +449,7 @@ public class SignConfigUI extends Screen {
             layoutEditRef = null;
         } else if (modeFlag == 0) {
             inEditingRow = null;
+            editingPreviewScroll = 0;
             sideEditing = -1;
         } else if (this.modeFlag < 0) {
             setter.accept(dispItems);

--- a/common/src/main/resources/assets/fangsu/lang/en_us.json
+++ b/common/src/main/resources/assets/fangsu/lang/en_us.json
@@ -52,5 +52,13 @@
   "ui.fangsu.sign.center": "Center",
   "ui.fangsu.sign.right": "Right",
   "ui.fangsu.sign.tooltip1": "Editing: %s",
-  "ui.fangsu.sign.tooltip2": "ESC: Back"
+  "ui.fangsu.sign.tooltip2": "ESC: Back",
+  "ui.fangsu.sign.edit_hint": "L: edit  R: delete",
+  "ui.fangsu.sign.layout_title": "MultiLine Layout",
+  "ui.fangsu.sign.layout_hint": "Left click to edit, right click to delete, click top/bottom slot to switch",
+  "ui.fangsu.sign.item.str": "Text",
+  "ui.fangsu.sign.item.img": "Image",
+  "ui.fangsu.sign.item.space": "Spacer",
+  "ui.fangsu.sign.item.multiline": "MultiLine",
+  "ui.fangsu.sign.item.unknown": "Unknown Item"
 }

--- a/common/src/main/resources/assets/fangsu/lang/zh_cn.json
+++ b/common/src/main/resources/assets/fangsu/lang/zh_cn.json
@@ -56,5 +56,13 @@
   "ui.fangsu.common.length": "长度",
   "ui.fangsu.sign.left": "左侧",
   "ui.fangsu.sign.center": "居中",
-  "ui.fangsu.sign.right": "右侧"
+  "ui.fangsu.sign.right": "右侧",
+  "ui.fangsu.sign.edit_hint": "左键编辑  右键删除",
+  "ui.fangsu.sign.layout_title": "多行布局",
+  "ui.fangsu.sign.layout_hint": "左键编辑，右键删除，点击上/下槽切换",
+  "ui.fangsu.sign.item.str": "文本",
+  "ui.fangsu.sign.item.img": "图片",
+  "ui.fangsu.sign.item.space": "间隔",
+  "ui.fangsu.sign.item.multiline": "多行布局",
+  "ui.fangsu.sign.item.unknown": "未知项目"
 }


### PR DESCRIPTION
### Motivation
- Reduce blurry/low-resolution G2D preview rendering and fix oversized row previews in the selection screen. 
- Allow inserting at the far-left of the editing preview by providing horizontal scrolling for the top preview area. 
- Fix the UnknownItem fallback drawing so the placeholder color/position is consistent and clearer. 
- Add palette tooltips and move hardcoded hints to localization entries so UI strings are localizable.

### Description
- Increased the G2D backing texture resolution and added `G2D_SCALE = 2` so the rendered previews are higher resolution and less blurry (`SignConfigUI.java`).
- Reduced the in-row preview unit height calculation for selection rows to avoid oversized previews and added `editingPreviewScroll` with clamped horizontal scrolling for the editing preview area to enable far-left insertion (`SignConfigUI.java`).
- Replaced hardcoded edit/layout hint strings with localization keys and added palette-hover tooltips showing localized item-type labels (`SignConfigUI.java`, `en_us.json`, `zh_cn.json`).
- Rewrote `UnknownItem.draw(...)` to use consistent integer rounding and a clearer bordered inner-fill placeholder style instead of the previous misaligned blocks (`UnknownItem.java`).
- Updated `common/src/main/resources/assets/fangsu/lang/en_us.json` and `zh_cn.json` to add new keys for edit hints, layout texts and palette item labels.

### Testing
- Attempted to compile with `./gradlew :common:compileJava`, but the Gradle wrapper download failed in this environment due to proxy returning `HTTP/1.1 403 Forbidden`, so no full compile was completed.
- Verified changes by inspecting and running local text/file checks (file diffs and code review) and committed the edits; no automated build/test succeeded in this environment due to network/proxy constraints.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_698de5a50814832ebade82dac4f6fbec)