### PR TITLE
Isolate client-only UI calls with `ClientHooks` to prevent dedicated server class load crashes

### DIFF
--- a/common/src/main/java/com/fangsu/blockEntities/BaseObjBlockEntity.java
+++ b/common/src/main/java/com/fangsu/blockEntities/BaseObjBlockEntity.java
@@ -1,6 +1,7 @@
 package com.fangsu.blockEntities;
 
 import com.fangsu.blocks.BaseObjBlock;
+import com.fangsu.client.ClientHooks;
 import com.fangsu.customItem.ModelSelectInfo;
 import com.fangsu.customItem.SubModelDispInfo;
 //#if FABRIC
@@ -23,11 +24,9 @@ import fabric.cn.zbx1425.sowcerext.model.ModelCluster;
 //#endif
 import com.fangsu.extraConfig.ConfigEntry;
 import com.fangsu.network.ModNetwork;
-import com.fangsu.ui.ObjBlockConfigScreen;
 import dev.architectury.networking.NetworkManager;
 import io.netty.buffer.Unpooled;
 import mtr.mappings.BlockEntityClientSerializableMapper;
-import net.minecraft.client.Minecraft;
 import net.minecraft.core.BlockPos;
 import net.minecraft.core.Direction;
 import net.minecraft.nbt.CompoundTag;
@@ -394,7 +393,7 @@ public abstract class BaseObjBlockEntity extends BlockEntity implements Syncable
 
     public final InteractionResult useWithBrush(@NotNull BlockState state, @NotNull Level level, @NotNull BlockPos pos, @NotNull Player player, @NotNull InteractionHand hand, @NotNull BlockHitResult hit) {
         if (level.isClientSide) {
-            Minecraft.getInstance().setScreen(new ObjBlockConfigScreen(this));
+            ClientHooks.openObjBlockConfigScreen(this);
         }
         return InteractionResult.sidedSuccess(level.isClientSide);
     }

--- a/common/src/main/java/com/fangsu/blockEntities/BlockEntitySign.java
+++ b/common/src/main/java/com/fangsu/blockEntities/BlockEntitySign.java
@@ -1,6 +1,7 @@
 package com.fangsu.blockEntities;
 
 import com.fangsu.Main;
+import com.fangsu.client.ClientHooks;
 import com.fangsu.customItem.CustomItemLoader;
 import com.fangsu.customItem.ModelSelectInfo;
 import com.fangsu.customItem.SubModelDispInfo;
@@ -14,14 +15,10 @@ import com.fangsu.scripting.ModelHelper;
 import com.fangsu.signItems.SignDrawContext;
 import com.fangsu.signItems.SignItem;
 import com.fangsu.signItems.SignItemFactory;
-import com.fangsu.ui.PlatformSelectionScreen;
-import com.fangsu.ui.RouteSelectionScreen;
-import com.fangsu.ui.SignConfigUI;
 import com.fangsu.utils.CollisionBoxUtil;
 import com.fangsu.utils.CustomItemHelper;
 import com.fangsu.utils.ResourceUtil;
 import com.google.gson.*;
-import net.minecraft.client.Minecraft;
 import net.minecraft.core.BlockPos;
 import net.minecraft.network.FriendlyByteBuf;
 import net.minecraft.network.chat.Component;
@@ -355,16 +352,13 @@ public class BlockEntitySign extends BaseObjBlockEntity implements Syncable {
         infos.add(new SubModelMethodInfo(Component.translatable("ui.fangsu.sign.editSign"), () -> {
             if (itemsFront == null) itemsFront = new HashMap<>();
             if (itemsBack == null) itemsBack = new HashMap<>();
-            Minecraft.getInstance().execute(() -> {
-                Minecraft.getInstance().setScreen(new SignConfigUI(2, List.of(itemsFront, itemsBack),
-                        (list) -> {
-                            itemsFront = list.get(0);
-                            itemsBack = list.get(1);
-                            extraConfigs.put("itemsFront", toItemsJson(itemsFront).toString());
-                            extraConfigs.put("itemsBack", toItemsJson(itemsBack).toString());
-                            requiresRedraw = true;
-                            sendUpdateC2S();
-                        }));
+            ClientHooks.openSignConfigScreen(itemsFront, itemsBack, (front, back) -> {
+                itemsFront = front;
+                itemsBack = back;
+                extraConfigs.put("itemsFront", toItemsJson(itemsFront).toString());
+                extraConfigs.put("itemsBack", toItemsJson(itemsBack).toString());
+                requiresRedraw = true;
+                sendUpdateC2S();
             });
         }));
         return infos;

--- a/common/src/main/java/com/fangsu/client/ClientHooks.java
+++ b/common/src/main/java/com/fangsu/client/ClientHooks.java
@@ -1,0 +1,28 @@
+package com.fangsu.client;
+
+import com.fangsu.blockEntities.BaseObjBlockEntity;
+import com.fangsu.signItems.SignItem;
+import dev.architectury.injectables.annotations.ExpectPlatform;
+
+import java.util.List;
+import java.util.Map;
+import java.util.function.BiConsumer;
+
+public final class ClientHooks {
+    private ClientHooks() {
+    }
+
+    @ExpectPlatform
+    public static void openObjBlockConfigScreen(BaseObjBlockEntity blockEntity) {
+        throw new AssertionError();
+    }
+
+    @ExpectPlatform
+    public static void openSignConfigScreen(
+            Map<String, List<SignItem>> itemsFront,
+            Map<String, List<SignItem>> itemsBack,
+            BiConsumer<Map<String, List<SignItem>>, Map<String, List<SignItem>>> onSave
+    ) {
+        throw new AssertionError();
+    }
+}

--- a/fabric/src/main/java/com/fangsu/client/ClientHooksImpl.java
+++ b/fabric/src/main/java/com/fangsu/client/ClientHooksImpl.java
@@ -1,0 +1,28 @@
+package com.fangsu.client;
+
+import com.fangsu.blockEntities.BaseObjBlockEntity;
+import com.fangsu.signItems.SignItem;
+import com.fangsu.ui.ObjBlockConfigScreen;
+import com.fangsu.ui.SignConfigUI;
+import net.minecraft.client.Minecraft;
+
+import java.util.List;
+import java.util.Map;
+import java.util.function.BiConsumer;
+
+public final class ClientHooksImpl {
+    private ClientHooksImpl() {
+    }
+
+    public static void openObjBlockConfigScreen(BaseObjBlockEntity blockEntity) {
+        Minecraft.getInstance().setScreen(new ObjBlockConfigScreen(blockEntity));
+    }
+
+    public static void openSignConfigScreen(
+            Map<String, List<SignItem>> itemsFront,
+            Map<String, List<SignItem>> itemsBack,
+            BiConsumer<Map<String, List<SignItem>>, Map<String, List<SignItem>>> onSave
+    ) {
+        Minecraft.getInstance().execute(() -> Minecraft.getInstance().setScreen(new SignConfigUI(2, List.of(itemsFront, itemsBack), list -> onSave.accept(list.get(0), list.get(1)))));
+    }
+}

--- a/forge/src/main/java/com/fangsu/client/ClientHooksImpl.java
+++ b/forge/src/main/java/com/fangsu/client/ClientHooksImpl.java
@@ -1,0 +1,28 @@
+package com.fangsu.client;
+
+import com.fangsu.blockEntities.BaseObjBlockEntity;
+import com.fangsu.signItems.SignItem;
+import com.fangsu.ui.ObjBlockConfigScreen;
+import com.fangsu.ui.SignConfigUI;
+import net.minecraft.client.Minecraft;
+
+import java.util.List;
+import java.util.Map;
+import java.util.function.BiConsumer;
+
+public final class ClientHooksImpl {
+    private ClientHooksImpl() {
+    }
+
+    public static void openObjBlockConfigScreen(BaseObjBlockEntity blockEntity) {
+        Minecraft.getInstance().setScreen(new ObjBlockConfigScreen(blockEntity));
+    }
+
+    public static void openSignConfigScreen(
+            Map<String, List<SignItem>> itemsFront,
+            Map<String, List<SignItem>> itemsBack,
+            BiConsumer<Map<String, List<SignItem>>, Map<String, List<SignItem>>> onSave
+    ) {
+        Minecraft.getInstance().execute(() -> Minecraft.getInstance().setScreen(new SignConfigUI(2, List.of(itemsFront, itemsBack), list -> onSave.accept(list.get(0), list.get(1)))));
+    }
+}


### PR DESCRIPTION
### Motivation

- Dedicated server startup could fail because common classes directly referenced client-only classes (e.g. `Minecraft.getInstance()` and UI screens), causing classloading issues on server runtime.
- The goal is to remove client-only imports from shared/common code and route UI operations through a platform hook so server runtime never touches client classes.

### Description

- Added a common platform hook `ClientHooks` with `@ExpectPlatform` methods `openObjBlockConfigScreen` and `openSignConfigScreen` to move UI opening logic out of common code (`common/src/main/java/com/fangsu/client/ClientHooks.java`).
- Replaced direct client UI calls in `BaseObjBlockEntity` with `ClientHooks.openObjBlockConfigScreen(this)` to avoid `Minecraft` references in common code (`common/src/main/java/com/fangsu/blockEntities/BaseObjBlockEntity.java`).
- Replaced the `Minecraft.getInstance()` / `SignConfigUI` usages in `BlockEntitySign` with `ClientHooks.openSignConfigScreen(...)` and removed client imports from that common class (`common/src/main/java/com/fangsu/blockEntities/BlockEntitySign.java`).
- Implemented platform-specific client-side implementations `ClientHooksImpl` for Fabric and Forge that perform the actual `Minecraft` UI operations (`fabric/src/main/java/com/fangsu/client/ClientHooksImpl.java` and `forge/src/main/java/com/fangsu/client/ClientHooksImpl.java`).

### Testing

- Ran a code scan to confirm removal of direct client imports from common block entity classes using a search for `net.minecraft.client` in `common/src/main/java/com/fangsu/blockEntities`, which returned only client-side render classes and confirmed the refactor removed problematic imports in the shared code (success).
- Verified the new `ClientHooks` type and platform implementations are present in `common`, `fabric`, and `forge` source trees and that `BaseObjBlockEntity` / `BlockEntitySign` now call the hook methods (success).
- Attempted a complete Gradle build (`./gradlew build -x test`), but the environment blocked Gradle wrapper download via a network proxy (HTTP 403), so a full build could not be completed in this environment (network restriction failure).

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69917aaaaa70832e9f606153a793c7d5)