### PR TITLE
fix(ticket): move custom zone under MTR and add ticket machine

### DIFF
--- a/common/src/main/java/com/fangsu/Main.java
+++ b/common/src/main/java/com/fangsu/Main.java
@@ -2,6 +2,7 @@ package com.fangsu;
 
 import com.fangsu.blocks.ModBlocks;
 import com.fangsu.customItem.CustomItems;
+import com.fangsu.items.ModItems;
 import com.fangsu.network.ModNetwork;
 import com.fangsu.signItems.SignItemFactory;
 import com.fangsu.ui.ModMenus;
@@ -30,6 +31,7 @@ public final class Main {
         //#endif
 
         ModBlocks.init();
+        ModItems.init();
         RegisterUtil.register();
         ModMenus.init();
         ModNetwork.init();

--- a/common/src/main/java/com/fangsu/blockEntities/BlockEntityTicketBarrier.java
+++ b/common/src/main/java/com/fangsu/blockEntities/BlockEntityTicketBarrier.java
@@ -75,6 +75,14 @@ public class BlockEntityTicketBarrier extends BaseObjBlockEntity {
         ensureExtraConfig("fareType", "0");
         ensureExtraConfig("isExit", "false");
         ensureExtraConfig("fareVal", "10");
+        ensureExtraConfig("useCustomZone", "false");
+        ensureExtraConfig("customZone", "0");
+        ensureExtraConfig("customDisplayName", "");
+        int fareType = getExtraConfigInt("fareType", 0);
+        if (fareType == 2) {
+            extraConfigs.put("fareType", "0");
+            extraConfigs.put("useCustomZone", "true");
+        }
 
         ObjBlockScriptContext ctx = this.scriptContext;
         BaseObjBlockEntity entity = this;
@@ -256,8 +264,7 @@ public class BlockEntityTicketBarrier extends BaseObjBlockEntity {
                 new ConfigSpec("list"),
                 List.of(
                         Component.translatable("ui.fangsu.ticketbarrier.modeMtr"),
-                        Component.translatable("ui.fangsu.ticketbarrier.modeFareOnce"),
-                        Component.translatable("ui.fangsu.ticketbarrier.modeCustom")
+                        Component.translatable("ui.fangsu.ticketbarrier.modeFareOnce")
                 ),
                 () -> getExtraConfigInt("fareType", 0),
                 (v) -> extra.put("fareType", v.toString())
@@ -267,6 +274,15 @@ public class BlockEntityTicketBarrier extends BaseObjBlockEntity {
                 new ConfigSpec("bool"),
                 () -> getExtraConfigBool("isExit", false),
                 (v) -> extra.put("isExit", v.toString())
+        ).setShowCondition(v -> {
+            int fareType = getExtraConfigInt("fareType", 0);
+            return fareType == 0;
+        }));
+        configs.add(new BoolConfig(
+                Component.translatable("ui.fangsu.ticketbarrier.useCustomZone"),
+                new ConfigSpec("bool"),
+                () -> getExtraConfigBool("useCustomZone", false),
+                (v) -> extra.put("useCustomZone", v.toString())
         ).setShowCondition(v -> 0 == getExtraConfigInt("fareType", 0)));
         configs.add(new NumberInputConfig(
                 Component.translatable("ui.fangsu.ticketbarrier.fareVal"),
@@ -277,6 +293,21 @@ public class BlockEntityTicketBarrier extends BaseObjBlockEntity {
                 () -> (float) getExtraConfigInt("fareVal", 10),
                 (v) -> extra.put("fareVal", String.valueOf(v.intValue()))
         ).setShowCondition(v -> 1 == getExtraConfigInt("fareType", 0)));
+        configs.add(new NumberInputConfig(
+                Component.translatable("ui.fangsu.ticketbarrier.customZone"),
+                new ConfigSpec("number_input")
+                        .setParam("max", new JsonPrimitive(32767))
+                        .setParam("min", new JsonPrimitive(-32768))
+                        .setParam("isInt", new JsonPrimitive(true)),
+                () -> (float) getExtraConfigInt("customZone", 0),
+                (v) -> extra.put("customZone", String.valueOf(v.intValue()))
+        ).setShowCondition(v -> 0 == getExtraConfigInt("fareType", 0) && getExtraConfigBool("useCustomZone", false)));
+        configs.add(new StringConfig(
+                Component.translatable("ui.fangsu.ticketbarrier.customDisplayName"),
+                new ConfigSpec("string"),
+                () -> extra.getOrDefault("customDisplayName", ""),
+                (v) -> extra.put("customDisplayName", v)
+        ).setShowCondition(v -> 0 == getExtraConfigInt("fareType", 0) && getExtraConfigBool("useCustomZone", false)));
         return configs;
     }
 

--- a/common/src/main/java/com/fangsu/blocks/BlockTicketMachine.java
+++ b/common/src/main/java/com/fangsu/blocks/BlockTicketMachine.java
@@ -1,0 +1,98 @@
+package com.fangsu.blocks;
+
+import net.minecraft.core.BlockPos;
+import net.minecraft.core.Direction;
+import net.minecraft.world.item.context.BlockPlaceContext;
+import net.minecraft.world.level.BlockGetter;
+import net.minecraft.world.level.Level;
+import net.minecraft.world.level.LevelAccessor;
+import net.minecraft.world.level.block.Block;
+import net.minecraft.world.level.block.Mirror;
+import net.minecraft.world.level.block.Rotation;
+import net.minecraft.world.level.block.state.BlockBehaviour;
+import net.minecraft.world.level.block.state.BlockState;
+import net.minecraft.world.level.block.state.StateDefinition;
+import net.minecraft.world.level.block.state.properties.BlockStateProperties;
+import net.minecraft.world.level.block.state.properties.DirectionProperty;
+import net.minecraft.world.level.block.state.properties.DoubleBlockHalf;
+import net.minecraft.world.level.block.state.properties.EnumProperty;
+import net.minecraft.world.phys.shapes.CollisionContext;
+import net.minecraft.world.phys.shapes.VoxelShape;
+import org.jetbrains.annotations.NotNull;
+import org.jetbrains.annotations.Nullable;
+
+public class BlockTicketMachine extends Block {
+    public static final DirectionProperty FACING = BlockStateProperties.HORIZONTAL_FACING;
+    public static final EnumProperty<DoubleBlockHalf> HALF = BlockStateProperties.DOUBLE_BLOCK_HALF;
+    private static final VoxelShape SHAPE = Block.box(2, 0, 2, 14, 16, 14);
+
+    public BlockTicketMachine() {
+        super(BlockBehaviour.Properties.of().strength(2).noOcclusion());
+        registerDefaultState(this.defaultBlockState().setValue(FACING, Direction.NORTH).setValue(HALF, DoubleBlockHalf.LOWER));
+    }
+
+    @Override
+    protected void createBlockStateDefinition(StateDefinition.Builder<Block, BlockState> builder) {
+        builder.add(FACING, HALF);
+    }
+
+    @Nullable
+    @Override
+    public BlockState getStateForPlacement(BlockPlaceContext context) {
+        BlockPos blockPos = context.getClickedPos();
+        Level level = context.getLevel();
+        if (blockPos.getY() >= level.getMaxBuildHeight() - 1) return null;
+        if (!level.getBlockState(blockPos.above()).canBeReplaced(context)) return null;
+        return this.defaultBlockState().setValue(FACING, context.getHorizontalDirection().getOpposite()).setValue(HALF, DoubleBlockHalf.LOWER);
+    }
+
+    @Override
+    public void setPlacedBy(Level level, BlockPos pos, BlockState state, @Nullable net.minecraft.world.entity.LivingEntity placer, net.minecraft.world.item.ItemStack stack) {
+        super.setPlacedBy(level, pos, state, placer, stack);
+        level.setBlock(pos.above(), state.setValue(HALF, DoubleBlockHalf.UPPER), 3);
+    }
+
+    @Override
+    public @NotNull BlockState updateShape(BlockState state, Direction direction, BlockState neighborState, LevelAccessor level, BlockPos pos, BlockPos neighborPos) {
+        DoubleBlockHalf half = state.getValue(HALF);
+        if (direction.getAxis() != Direction.Axis.Y) return super.updateShape(state, direction, neighborState, level, pos, neighborPos);
+
+        if (half == DoubleBlockHalf.LOWER && direction == Direction.UP) {
+            if (!neighborState.is(this) || neighborState.getValue(HALF) != DoubleBlockHalf.UPPER) {
+                return net.minecraft.world.level.block.Blocks.AIR.defaultBlockState();
+            }
+        }
+        if (half == DoubleBlockHalf.UPPER && direction == Direction.DOWN) {
+            if (!neighborState.is(this) || neighborState.getValue(HALF) != DoubleBlockHalf.LOWER) {
+                return net.minecraft.world.level.block.Blocks.AIR.defaultBlockState();
+            }
+        }
+        return super.updateShape(state, direction, neighborState, level, pos, neighborPos);
+    }
+
+    @Override
+    public void playerWillDestroy(Level level, BlockPos pos, BlockState state, net.minecraft.world.entity.player.Player player) {
+        DoubleBlockHalf half = state.getValue(HALF);
+        BlockPos otherPos = half == DoubleBlockHalf.LOWER ? pos.above() : pos.below();
+        BlockState otherState = level.getBlockState(otherPos);
+        if (otherState.is(this) && otherState.getValue(HALF) != half) {
+            level.setBlock(otherPos, net.minecraft.world.level.block.Blocks.AIR.defaultBlockState(), 35);
+        }
+        super.playerWillDestroy(level, pos, state, player);
+    }
+
+    @Override
+    public @NotNull VoxelShape getShape(BlockState state, BlockGetter level, BlockPos pos, CollisionContext context) {
+        return SHAPE;
+    }
+
+    @Override
+    public BlockState rotate(BlockState state, Rotation rotation) {
+        return state.setValue(FACING, rotation.rotate(state.getValue(FACING)));
+    }
+
+    @Override
+    public BlockState mirror(BlockState state, Mirror mirror) {
+        return state.rotate(mirror.getRotation(state.getValue(FACING)));
+    }
+}

--- a/common/src/main/java/com/fangsu/blocks/ModBlocks.java
+++ b/common/src/main/java/com/fangsu/blocks/ModBlocks.java
@@ -2,6 +2,7 @@ package com.fangsu.blocks;
 
 import com.fangsu.blockEntities.*;
 import com.fangsu.blocks.client.ModBlockClient;
+import com.fangsu.items.ModItems;
 import com.fangsu.utils.RegisterUtil;
 import dev.architectury.registry.registries.RegistrySupplier;
 import net.minecraft.network.chat.Component;
@@ -16,6 +17,7 @@ public class ModBlocks {
     public static final RegistrySupplier<Block> BLOCK_SCREENDOOR_GLASS = RegisterUtil.addBlock("screendoor_glass", BlockScreendoorGlass::new);
     public static final RegistrySupplier<Block> BLOCK_SIGN = RegisterUtil.addBlock("sign", BlockSign::new);
     public static final RegistrySupplier<Block> BLOCK_SIGN_ON_WALL = RegisterUtil.addBlock("sign_on_wall", BlockSignOnWall::new);
+    public static final RegistrySupplier<Block> BLOCK_TICKET_MACHINE = RegisterUtil.addBlock("ticket_machine", BlockTicketMachine::new);
 
     public static final RegistrySupplier<BlockEntityType<BaseObjBlockEntity>> BLOCK_ENTITY_TICKET_BARRIER =
             RegisterUtil.addBlockEntity("block_entity_ticket_barrier", BLOCK_TICKET_BARRIER, BlockEntityTicketBarrier::new);
@@ -33,7 +35,7 @@ public class ModBlocks {
     public static final RegistrySupplier<Item> ITEM_SCREENDOOR_GLASS = RegisterUtil.addBlockItem("screendoor_glass", BLOCK_SCREENDOOR_GLASS);
     public static final RegistrySupplier<Item> ITEM_SIGN = RegisterUtil.addBlockItem("sign", BLOCK_SIGN);
     public static final RegistrySupplier<Item> ITEM_SIGN_ON_WALL = RegisterUtil.addBlockItem("sign_on_wall", BLOCK_SIGN_ON_WALL);
-
+    public static final RegistrySupplier<Item> ITEM_TICKET_MACHINE = RegisterUtil.addBlockItem("ticket_machine", BLOCK_TICKET_MACHINE);
     public static final RegistrySupplier<Block> BLOCK_COLLISION_COMPENSATOR =
             RegisterUtil.addBlock("collision_compensation_block", BlockCollisionCompensator::new);
     public static final RegistrySupplier<Item> ITEM_COLLISION_COMPENSATOR =
@@ -48,7 +50,9 @@ public class ModBlocks {
             ITEM_SCREENDOOR_GLASS,
             ITEM_SIGN,
             ITEM_SIGN_ON_WALL,
-            ITEM_COLLISION_COMPENSATOR
+            ITEM_TICKET_MACHINE,
+            ITEM_COLLISION_COMPENSATOR,
+            ModItems.ITEM_IC_CARD
     );
 
     public static void init() {

--- a/common/src/main/java/com/fangsu/items/ItemIcCard.java
+++ b/common/src/main/java/com/fangsu/items/ItemIcCard.java
@@ -1,0 +1,72 @@
+package com.fangsu.items;
+
+import com.fangsu.ticketSystem.FareInfo;
+import com.fangsu.ticketSystem.FareType;
+import net.minecraft.nbt.CompoundTag;
+import net.minecraft.network.chat.Component;
+import net.minecraft.world.entity.player.Player;
+import net.minecraft.world.item.Item;
+import net.minecraft.world.item.ItemStack;
+import net.minecraft.world.level.Level;
+
+public class ItemIcCard extends Item implements TicketItem {
+
+    private static final String BALANCE = "Balance";
+    private static final String ENTERED = "Entered";
+    private static final String ENTRY_ZONE = "EntryZone";
+
+    private static final int BASE_FARE = 2;
+    private static final int ZONE_FARE = 1;
+
+    public ItemIcCard() {
+        super(new Item.Properties().stacksTo(1));
+    }
+
+    @Override
+    public boolean enter(Level world, Player player, ItemStack stack, FareInfo info) {
+        CompoundTag tag = stack.getOrCreateTag();
+        if (!tag.contains(BALANCE)) tag.putInt(BALANCE, 100);
+        if (tag.getBoolean(ENTERED)) {
+            player.displayClientMessage(Component.translatable("gui.mtr.already_entered"), true);
+            return false;
+        }
+
+        tag.putBoolean(ENTERED, true);
+        tag.putInt(ENTRY_ZONE, info.value());
+        String name = info.displayName() == null || info.displayName().isEmpty() ? Component.translatable("block.fangsu.ticket_barrier").getString() : info.displayName();
+        player.displayClientMessage(Component.translatable("msg.fangsu.ticketbarrier.enterCustom", name), true);
+        return true;
+    }
+
+    @Override
+    public boolean exit(Level world, Player player, ItemStack stack, FareInfo info) {
+        CompoundTag tag = stack.getOrCreateTag();
+        if (!tag.getBoolean(ENTERED)) {
+            player.displayClientMessage(Component.translatable("msg.fangsu.ticketbarrier.notEntered"), true);
+            return false;
+        }
+
+        if (!tag.contains(BALANCE)) tag.putInt(BALANCE, 100);
+        int balance = tag.getInt(BALANCE);
+        int fare = computeFare(tag.getInt(ENTRY_ZONE), info);
+        if (balance < fare) {
+            player.displayClientMessage(Component.translatable("gui.mtr.insufficient_balance", balance), true);
+            return false;
+        }
+
+        tag.putInt(BALANCE, balance - fare);
+        tag.putBoolean(ENTERED, false);
+        tag.putInt(ENTRY_ZONE, 0);
+        String name = info.displayName() == null || info.displayName().isEmpty() ? Component.translatable("block.fangsu.ticket_barrier").getString() : info.displayName();
+        player.displayClientMessage(Component.translatable("msg.fangsu.ticketbarrier.exitCustom", name, fare, balance - fare), true);
+        return true;
+    }
+
+    private int computeFare(int entryZone, FareInfo info) {
+        if (info.type() == FareType.FARE_ONCE) {
+            return Math.max(0, info.value());
+        }
+        int distance = Math.abs(entryZone - info.value());
+        return BASE_FARE + ZONE_FARE * distance;
+    }
+}

--- a/common/src/main/java/com/fangsu/items/ItemSingleJourneyTicket.java
+++ b/common/src/main/java/com/fangsu/items/ItemSingleJourneyTicket.java
@@ -1,6 +1,7 @@
 package com.fangsu.items;
 
 import com.fangsu.ticketSystem.FareInfo;
+import com.fangsu.ticketSystem.FareType;
 import com.fangsu.ticketSystem.SingleJourneyTicketData;
 import net.minecraft.network.chat.Component;
 import net.minecraft.world.entity.player.Player;
@@ -10,34 +11,53 @@ import net.minecraft.world.level.Level;
 
 public class ItemSingleJourneyTicket extends Item implements TicketItem {
     public ItemSingleJourneyTicket() {
-        super(new Item.Properties()
-                .stacksTo(1)
-        );
+        super(new Item.Properties().stacksTo(1));
     }
 
     @Override
     public boolean enter(Level world, Player player, ItemStack stack, FareInfo info) {
+        if (SingleJourneyTicketData.hasEntered(stack)) {
+            player.displayClientMessage(Component.translatable("ui.fangsu.ticket.error"), true);
+            return false;
+        }
+
         switch (info.type()) {
-            case MTR:
-                if (SingleJourneyTicketData.hasEntered(stack)) {
-                    player.displayClientMessage(Component.translatable("ui.fangsu.ticket.error"), true);
-                    return false;
-                } else {
-                    SingleJourneyTicketData.enter(stack, info.value());
-                }
-            case FARE_ONCE:
+            case MTR, CUSTOM -> {
+                SingleJourneyTicketData.enter(stack, info.value());
+                return true;
+            }
+            case FARE_ONCE -> {
                 if (SingleJourneyTicketData.getPrice(stack) >= info.value()) {
                     stack.shrink(1);
                     player.displayClientMessage(Component.translatable("ui.fangsu.ticket.success"), true);
                     return true;
                 }
-            default:
                 return false;
+            }
+            default -> {
+                return false;
+            }
         }
     }
 
     @Override
     public boolean exit(Level world, Player player, ItemStack stack, FareInfo info) {
+        if (!SingleJourneyTicketData.hasEntered(stack)) {
+            player.displayClientMessage(Component.translatable("ui.fangsu.ticket.error"), true);
+            return false;
+        }
+
+        if (info.type() == FareType.MTR || info.type() == FareType.CUSTOM) {
+            int fare = Math.abs(SingleJourneyTicketData.getEntryZone(stack) - info.value());
+            if (SingleJourneyTicketData.getPrice(stack) < fare) {
+                player.displayClientMessage(Component.translatable("ui.fangsu.ticket.error"), true);
+                return false;
+            }
+            stack.shrink(1);
+            player.displayClientMessage(Component.translatable("ui.fangsu.ticket.success"), true);
+            return true;
+        }
+
         return false;
     }
 }

--- a/common/src/main/java/com/fangsu/items/ModItems.java
+++ b/common/src/main/java/com/fangsu/items/ModItems.java
@@ -1,0 +1,12 @@
+package com.fangsu.items;
+
+import com.fangsu.utils.RegisterUtil;
+import dev.architectury.registry.registries.RegistrySupplier;
+import net.minecraft.world.item.Item;
+
+public class ModItems {
+    public static final RegistrySupplier<Item> ITEM_IC_CARD = RegisterUtil.addItem("ic_card", ItemIcCard::new);
+
+    public static void init() {
+    }
+}

--- a/common/src/main/java/com/fangsu/ticketSystem/FareInfo.java
+++ b/common/src/main/java/com/fangsu/ticketSystem/FareInfo.java
@@ -1,4 +1,7 @@
 package com.fangsu.ticketSystem;
 
-public record FareInfo(FareType type, int value) {
+public record FareInfo(FareType type, int value, String displayName) {
+    public FareInfo(FareType type, int value) {
+        this(type, value, "");
+    }
 }

--- a/common/src/main/java/com/fangsu/ticketSystem/TicketBarrierHandler.java
+++ b/common/src/main/java/com/fangsu/ticketSystem/TicketBarrierHandler.java
@@ -6,6 +6,7 @@ import net.minecraft.network.chat.Component;
 import net.minecraft.world.InteractionHand;
 import net.minecraft.world.InteractionResult;
 import net.minecraft.world.entity.player.Player;
+import net.minecraft.world.item.ItemStack;
 import net.minecraft.world.level.Level;
 import net.minecraft.world.phys.BlockHitResult;
 
@@ -16,13 +17,6 @@ public final class TicketBarrierHandler {
     private TicketBarrierHandler() {
     }
 
-    /**
-     * 玩家在闸机使用票据
-     * 支持：
-     * - 纸质客票（fareType 0）
-     * - 单次扣费（fareType 1）
-     * - 单程票 / IC 卡通过 IJourneyTicket 接口扩展
-     */
     public static InteractionResult handle(
             Level level,
             BlockPos pos,
@@ -39,64 +33,54 @@ public final class TicketBarrierHandler {
 
         int fareType = Integer.parseInt(extraConfigs.getOrDefault("fareType", "0"));
         boolean isExit = Boolean.parseBoolean(extraConfigs.getOrDefault("isExit", "false"));
+        boolean useCustomZone = Boolean.parseBoolean(extraConfigs.getOrDefault("useCustomZone", "false"));
 
         switch (fareType) {
-
-            case 0: // 纸质客票
-                if (!isExit) { // entrance
+            case 0:
+                if (useCustomZone) {
+                    int customZone = Integer.parseInt(extraConfigs.getOrDefault("customZone", "0"));
+                    String customDisplayName = extraConfigs.getOrDefault("customDisplayName", "");
+                    ItemStack stack = player.getItemInHand(hand);
+                    if (stack.isEmpty() || !(stack.getItem() instanceof TicketItem ticket)) {
+                        player.displayClientMessage(Component.translatable("msg.fangsu.ticketbarrier.requireCard"), true);
+                        return InteractionResult.PASS;
+                    }
+                    boolean success = isExit
+                            ? ticket.exit(level, player, stack, new FareInfo(FareType.CUSTOM, customZone, customDisplayName))
+                            : ticket.enter(level, player, stack, new FareInfo(FareType.CUSTOM, customZone, customDisplayName));
+                    if (!success) return InteractionResult.PASS;
+                    extraConfigs.put("isOpen", "true");
+                    sendUpdateC2S.run();
+                    return InteractionResult.SUCCESS;
+                }
+                if (!isExit) {
                     if (MtrTicketSystem.enter(level, pos, player)) {
                         extraConfigs.put("isOpen", "true");
                         sendUpdateC2S.run();
                         return InteractionResult.SUCCESS;
-                    } else return InteractionResult.PASS;
-                } else { // exit
+                    }
+                } else {
                     if (MtrTicketSystem.exit(level, pos, player)) {
                         extraConfigs.put("isOpen", "true");
                         sendUpdateC2S.run();
                         return InteractionResult.SUCCESS;
-                    } else return InteractionResult.PASS;
+                    }
                 }
+                return InteractionResult.PASS;
 
-            case 1: // 单次扣费
+            case 1:
                 MtrTicketSystem.addObjectivesIfMissing(level);
                 var balance = MtrTicketSystem.getScore(level, player, MtrTicketSystem.BALANCE_OBJECTIVE);
                 int val = Integer.parseInt(extraConfigs.getOrDefault("fareVal", "10"));
                 if (balance.getScore() < val) {
                     player.displayClientMessage(Component.translatable("gui.mtr.insufficient_balance", balance.getScore()), true);
                     return InteractionResult.PASS;
-                } else {
-                    balance.add(-val);
-                    player.displayClientMessage(
-                            Component.translatable("msg.fangsu.ticketbarrier.fareOnce", val, balance.getScore()),
-                            true
-                    );
-                    extraConfigs.put("isOpen", "true");
-                    sendUpdateC2S.run();
-                    return InteractionResult.SUCCESS;
                 }
-
-            case 3: // 自定义计费模型（扩展 IJourneyTicket 逻辑可接入这里）
-                // 如果玩家手持票据，实现 IJourneyTicket 接口就可以直接处理
-                var stack = player.getItemInHand(hand);
-                if (!stack.isEmpty() && stack.getItem() instanceof TicketItem ticket) {
-                    boolean success = isExit
-                            ? ticket.exit(level, player, stack, new FareInfo(FareType.CUSTOM, 0))
-                            : ticket.enter(level, player, stack, new FareInfo(FareType.CUSTOM, 0));
-
-                    if (success) {
-                        extraConfigs.put("isOpen", "true");
-                        sendUpdateC2S.run();
-                        return InteractionResult.SUCCESS;
-                    } else {
-                        return InteractionResult.PASS;
-                    }
-                } else {
-                    // fallback 提示
-                    player.displayClientMessage(Component.translatable("刷卡入闸"), true);
-                    extraConfigs.put("isOpen", "true");
-                    sendUpdateC2S.run();
-                    return InteractionResult.SUCCESS;
-                }
+                balance.add(-val);
+                player.displayClientMessage(Component.translatable("msg.fangsu.ticketbarrier.fareOnce", val, balance.getScore()), true);
+                extraConfigs.put("isOpen", "true");
+                sendUpdateC2S.run();
+                return InteractionResult.SUCCESS;
 
             default:
                 return InteractionResult.PASS;

--- a/common/src/main/resources/assets/fangsu/blockstates/ticket_machine.json
+++ b/common/src/main/resources/assets/fangsu/blockstates/ticket_machine.json
@@ -1,0 +1,13 @@
+{
+  "variants": {
+    "facing=north,half=lower": { "model": "fangsu:block/ticket_machine_lower" },
+    "facing=east,half=lower": { "model": "fangsu:block/ticket_machine_lower", "y": 90 },
+    "facing=south,half=lower": { "model": "fangsu:block/ticket_machine_lower", "y": 180 },
+    "facing=west,half=lower": { "model": "fangsu:block/ticket_machine_lower", "y": 270 },
+
+    "facing=north,half=upper": { "model": "fangsu:block/ticket_machine_upper" },
+    "facing=east,half=upper": { "model": "fangsu:block/ticket_machine_upper", "y": 90 },
+    "facing=south,half=upper": { "model": "fangsu:block/ticket_machine_upper", "y": 180 },
+    "facing=west,half=upper": { "model": "fangsu:block/ticket_machine_upper", "y": 270 }
+  }
+}

--- a/common/src/main/resources/assets/fangsu/lang/en_us.json
+++ b/common/src/main/resources/assets/fangsu/lang/en_us.json
@@ -24,7 +24,7 @@
   "ui.fangsu.ticketbarrier.fareVal": "Fare Amount",
   "ui.fangsu.ticketbarrier.modeMtr": "MTR Fare Calculation",
   "ui.fangsu.ticketbarrier.modeFareOnce": "Fixed Fare",
-  "ui.fangsu.ticketbarrier.modeCustom": "Custom (Not Implemented Yet)",
+  "ui.fangsu.ticketbarrier.modeCustom": "Custom Fare Zone",
   "ui.fangsu.screendoor.doorSide": "Door Opening Side",
   "ui.fangsu.screendoor.doorSideLeft": "Left",
   "ui.fangsu.screendoor.doorSideRight": "Right",
@@ -71,5 +71,14 @@
   "ui.fangsu.sign.leftPolePos": "Left Pole Position",
   "ui.fangsu.sign.dispRightPole": "Show Right Pole",
   "ui.fangsu.sign.rightPolePos": "Right Pole Position",
-  "ui.fangsu.sign.editSign": "Edit Sign Content"
+  "ui.fangsu.sign.editSign": "Edit Sign Content",
+  "ui.fangsu.ticketbarrier.customZone": "Custom Fare Zone",
+  "ui.fangsu.ticketbarrier.customDisplayName": "Display Name",
+  "msg.fangsu.ticketbarrier.requireCard": "Please hold a ticket or IC card to pass",
+  "msg.fangsu.ticketbarrier.enterCustom": "Entered at %s",
+  "msg.fangsu.ticketbarrier.exitCustom": "Exited at %s, Fare: %s, Balance: %s",
+  "msg.fangsu.ticketbarrier.notEntered": "Not entered yet",
+  "item.fangsu.ic_card": "IC Card",
+  "ui.fangsu.ticketbarrier.useCustomZone": "Use Custom Fare Zone",
+  "block.fangsu.ticket_machine": "Ticket Vending Machine"
 }

--- a/common/src/main/resources/assets/fangsu/lang/zh_cn.json
+++ b/common/src/main/resources/assets/fangsu/lang/zh_cn.json
@@ -24,7 +24,7 @@
   "ui.fangsu.ticketbarrier.fareVal": "扣款金额",
   "ui.fangsu.ticketbarrier.modeMtr": "MTR计费",
   "ui.fangsu.ticketbarrier.modeFareOnce": "固定收费",
-  "ui.fangsu.ticketbarrier.modeCustom": "自定义(还没做)",
+  "ui.fangsu.ticketbarrier.modeCustom": "自定义计费区",
   "ui.fangsu.screendoor.doorSide": "开门方向",
   "ui.fangsu.screendoor.doorSideLeft": "左",
   "ui.fangsu.screendoor.doorSideRight": "右",
@@ -73,5 +73,14 @@
   "ui.fangsu.sign.rightPolePos": "右杆位置",
   "ui.fangsu.sign.editSign": "指示牌内容编辑",
   "ui.fangsu.ticket.error": "请前往服务中心",
-  "ui.fangsu.ticket.success": "过闸成功"
+  "ui.fangsu.ticket.success": "过闸成功",
+  "ui.fangsu.ticketbarrier.customZone": "自定义计费区",
+  "ui.fangsu.ticketbarrier.customDisplayName": "显示名称",
+  "msg.fangsu.ticketbarrier.requireCard": "请手持单程票或IC卡刷卡",
+  "msg.fangsu.ticketbarrier.enterCustom": "已在 %s 入闸",
+  "msg.fangsu.ticketbarrier.exitCustom": "已在 %s 出闸，扣费 %s，余额 %s",
+  "msg.fangsu.ticketbarrier.notEntered": "尚未入闸",
+  "item.fangsu.ic_card": "IC卡",
+  "ui.fangsu.ticketbarrier.useCustomZone": "使用自定义计费区",
+  "block.fangsu.ticket_machine": "售票机"
 }

--- a/common/src/main/resources/assets/fangsu/models/block/ticket_machine_lower.json
+++ b/common/src/main/resources/assets/fangsu/models/block/ticket_machine_lower.json
@@ -1,0 +1,12 @@
+{
+  "parent": "block/cube",
+  "textures": {
+    "particle": "fangsu:item/ticket_barrier",
+    "down": "fangsu:item/ticket_barrier",
+    "up": "fangsu:item/ticket_barrier",
+    "north": "fangsu:item/ticket_barrier",
+    "south": "fangsu:item/ticket_barrier",
+    "west": "fangsu:item/ticket_barrier",
+    "east": "fangsu:item/ticket_barrier"
+  }
+}

--- a/common/src/main/resources/assets/fangsu/models/block/ticket_machine_upper.json
+++ b/common/src/main/resources/assets/fangsu/models/block/ticket_machine_upper.json
@@ -1,0 +1,12 @@
+{
+  "parent": "block/cube",
+  "textures": {
+    "particle": "fangsu:item/ticket_barrier",
+    "down": "fangsu:item/ticket_barrier",
+    "up": "fangsu:item/ticket_barrier",
+    "north": "fangsu:item/ticket_barrier",
+    "south": "fangsu:item/ticket_barrier",
+    "west": "fangsu:item/ticket_barrier",
+    "east": "fangsu:item/ticket_barrier"
+  }
+}

--- a/common/src/main/resources/assets/fangsu/models/item/ic_card.json
+++ b/common/src/main/resources/assets/fangsu/models/item/ic_card.json
@@ -1,0 +1,6 @@
+{
+  "parent": "minecraft:item/generated",
+  "textures": {
+    "layer0": "minecraft:item/paper"
+  }
+}

--- a/common/src/main/resources/assets/fangsu/models/item/ticket_machine.json
+++ b/common/src/main/resources/assets/fangsu/models/item/ticket_machine.json
@@ -1,0 +1,3 @@
+{
+  "parent": "fangsu:block/ticket_machine_lower"
+}


### PR DESCRIPTION
### Motivation
- Address review feedback that the “Custom Fare Zone” must be an option under MTR fare calculation instead of a separate fare mode, and that item registrations (IC card) should live in `ModItems`, not `ModBlocks`, plus add a ticket vending machine block.

### Description
- Replace standalone `CUSTOM` fare mode with a boolean `useCustomZone` shown only when `fareType == MTR` and add migration so old `fareType == 2` becomes `fareType == 0` with `useCustomZone = true` in `BlockEntityTicketBarrier`.
- Update `TicketBarrierHandler` to branch inside `fareType == 0` on `useCustomZone` and, when enabled, require a `TicketItem` and call `enter/exit` with `FareInfo(FareType.CUSTOM, ...)` (preserving original MTR behavior when disabled).
- Move IC card registration out of `ModBlocks` into a new `ModItems` class and initialize it in `Main.init()`, and update the creative tab to reference `ModItems.ITEM_IC_CARD`.
- Add `ItemIcCard` implementing `TicketItem` with enter/exit, balance initialization, fare computation, and player feedback; extend `ItemSingleJourneyTicket` to support `MTR`/`CUSTOM` flows.
- Add a new two-block-tall `BlockTicketMachine` with correct placement, upper/lower half behavior, registration, and simple block/item model and blockstate resources; add corresponding localization keys for English and Chinese.

### Testing
- Ran repository checks: `git status --short` and `git log --oneline -n 2`, both succeeded; changes were committed as `fix(ticket): move custom zone under MTR and add ticket machine`.
- Attempted to compile Java with `bash ./gradlew :common:compileJava -x spotlessCheck`, but the Gradle wrapper download failed due to a network proxy error (`HTTP 403 Forbidden`), so full build/tests could not be run in this environment.
- Performed source inspections (searches/reads) to confirm the new branches, files and language keys were added and references updated (manual automated-style checks via `rg`/`sed`).

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6997f5919ba4832ea63a55cd15346f93)