### PR TITLE
Async PIDS script loading, lifecycle cleanup, and PIDS data/refactor

### DIFF
--- a/common/src/main/java/com/fangsu/blockEntities/BaseObjBlockEntity.java
+++ b/common/src/main/java/com/fangsu/blockEntities/BaseObjBlockEntity.java
@@ -58,6 +58,7 @@ public abstract class BaseObjBlockEntity extends BlockEntity implements Syncable
     protected boolean markedError = false;
 
     Map<String, String> extraConfigs = new HashMap<>();
+    private boolean disposed = false;
 
     public BaseObjBlockEntity(BlockEntityType<?> blockEntityType, BlockPos blockPos, BlockState blockState) {
         super(blockEntityType, blockPos, blockState);
@@ -260,6 +261,12 @@ public abstract class BaseObjBlockEntity extends BlockEntity implements Syncable
     }
 
     public abstract void whenLoading();
+
+    /**
+     * Called when this block entity is being disposed (e.g. chunk unload / removal).
+     */
+    public void whenDisposing() {
+    }
 
     public abstract void whenRendering();
 
@@ -476,6 +483,21 @@ public abstract class BaseObjBlockEntity extends BlockEntity implements Syncable
     }
 
     public void afterChangeModel() {
+    }
+
+    @Override
+    public void setRemoved() {
+        if (!disposed) {
+            disposed = true;
+            whenDisposing();
+        }
+        super.setRemoved();
+    }
+
+    @Override
+    public void clearRemoved() {
+        disposed = false;
+        super.clearRemoved();
     }
 
     public record BaseObjC2SData(

--- a/common/src/main/java/com/fangsu/blockEntities/BlockEntityPids.java
+++ b/common/src/main/java/com/fangsu/blockEntities/BlockEntityPids.java
@@ -17,11 +17,6 @@ import com.fangsu.userScripts.ScriptHolderBase;
 import com.fangsu.userScripts.ScriptManager;
 import com.fangsu.utils.*;
 import com.google.gson.JsonElement;
-import mtr.client.ClientData;
-import mtr.data.Platform;
-import mtr.data.Route;
-import mtr.data.ScheduleEntry;
-import mtr.data.Station;
 import net.minecraft.core.BlockPos;
 import net.minecraft.core.Direction;
 import net.minecraft.network.FriendlyByteBuf;
@@ -36,9 +31,11 @@ import net.minecraft.world.phys.BlockHitResult;
 import net.minecraft.world.phys.Vec3;
 import net.minecraft.world.phys.shapes.Shapes;
 import net.minecraft.world.phys.shapes.VoxelShape;
-import org.joml.Vector3f;
 
 import java.util.*;
+import java.util.concurrent.CompletableFuture;
+import java.util.concurrent.ExecutorService;
+import java.util.concurrent.Executors;
 
 import static com.fangsu.blocks.ModBlocks.BLOCK_ENTITY_PIDS;
 
@@ -59,6 +56,12 @@ public class BlockEntityPids extends BaseObjBlockEntity {
     private Map<String, Object> drawState = new HashMap<>();
 
     private List<Long> plats;
+    private static final ExecutorService PIDS_SCRIPT_EXECUTOR = Executors.newSingleThreadExecutor(r -> {
+        Thread t = new Thread(r, "fangsu-pids-script-loader");
+        t.setDaemon(true);
+        return t;
+    });
+    private volatile int scriptLoadToken = 0;
 
     public BlockEntityPids(BlockPos blockPos, BlockState blockState) {
         super(BLOCK_ENTITY_PIDS.get(), blockPos, blockState);
@@ -100,30 +103,7 @@ public class BlockEntityPids extends BaseObjBlockEntity {
             }
             Main.LOGGER.info("texW={}, texH={}", texW, texH);
             if (current.containsKey("script")) {
-                ScriptManager manager = ScriptManager.getInstance();
-                ResourceLocation location = new ResourceLocation((String) current.get("script"));
-                manager.initHolder(location, PidsScriptHolder::new);
-                scriptHolder = manager.getHolder(location);
-
-                GraphicsTextureHelper gtHelper = GraphicsTextureHelper.getInstance();
-                gtHelper.removeDrawGraphic(getBlockPos());
-                gtHelper.addDrawGraphic(getBlockPos(),
-                        new GraphicsTextureHelper.DrawInfo(
-                                "PIDS_" + current.get("script") + "_" + plats.toString(),
-                                texW, texH, false, false
-                        ),
-                        (g, detail) -> {
-//                            Main.LOGGER.info("running draw");
-                            scriptHolder.runFunction("draw", g, drawState,
-                                    new DrawInfoPids((List<ArrivalInfo>) detail.get("arrivalInfoList"), new int[]{0, 0, texW, texH}, scriptContext, this)
-                                    , userExtraConfigs);
-                        },
-                        () -> {
-                            Map<String, Object> map = new HashMap<>();
-                            map.put("arrivalInfoList", getArrivalInfoList());
-                            return map;
-                        }
-                );
+                initScriptDrawingAsync(current);
             }
             boolean flipV = current.containsKey("flipV") && (boolean) current.get("flipV");
             String model = (String) current.get("model");
@@ -162,6 +142,58 @@ public class BlockEntityPids extends BaseObjBlockEntity {
             }
             markedError = true;
         }
+    }
+
+
+    private void initScriptDrawingAsync(Map<String, Object> current) {
+        GraphicsTextureHelper gtHelper = GraphicsTextureHelper.getInstance();
+        gtHelper.removeDrawGraphic(getBlockPos());
+
+        final int thisLoadToken = ++scriptLoadToken;
+        scriptHolder = null;
+
+        String scriptPath = (String) current.get("script");
+        ResourceLocation location = new ResourceLocation(scriptPath);
+
+        gtHelper.addDrawGraphic(getBlockPos(),
+                new GraphicsTextureHelper.DrawInfo(
+                        "PIDS_" + scriptPath + "_" + plats,
+                        texW, texH, false, false
+                ),
+                (g, detail) -> {
+                    ScriptHolderBase holder = scriptHolder;
+                    if (holder == null) return;
+                    holder.runFunction("draw", g, drawState,
+                            new DrawInfoPids((List<MtrUtil.PidsArrivalInfo>) detail.get("arrivalInfoList"), new int[]{0, 0, texW, texH}, scriptContext, this),
+                            userExtraConfigs);
+                },
+                () -> {
+                    Map<String, Object> map = new HashMap<>();
+                    map.put("arrivalInfoList", getArrivalInfoList());
+                    return map;
+                }
+        );
+
+        CompletableFuture.runAsync(() -> {
+            try {
+                ScriptManager manager = ScriptManager.getInstance();
+                manager.initHolder(location, PidsScriptHolder::new);
+                ScriptHolderBase loadedHolder = manager.getHolder(location);
+                if (loadedHolder != null && thisLoadToken == scriptLoadToken) {
+                    scriptHolder = loadedHolder;
+                }
+            } catch (Throwable e) {
+                Main.LOGGER.error("Failed to load PIDS script async {}", location, e);
+            }
+        }, PIDS_SCRIPT_EXECUTOR);
+    }
+
+    @Override
+    public void whenDisposing() {
+        scriptLoadToken++;
+        drawState.clear();
+        scriptHolder = null;
+        GraphicsTextureHelper.getInstance().removeDrawGraphic(getBlockPos());
     }
 
     @Override
@@ -375,183 +407,18 @@ public class BlockEntityPids extends BaseObjBlockEntity {
         };
     }
 
-    private List<ArrivalInfo> getArrivalInfoList() {
-        Vector3f pos = getBlockPos().getCenter().toVector3f();
-
-        List<ArrivalInfo> arrivalInfoList = new ArrayList<>();
-
-        if (plats == null || plats.isEmpty()) {
-            return arrivalInfoList;
-        }
-
-        for (Long platId : plats) {
-
-            Map<Long, Set<ScheduleEntry>> scheduleList = ClientData.SCHEDULES_FOR_PLATFORM;
-            Set<ScheduleEntry> currentSchedule = scheduleList.get(platId);
-            if (currentSchedule == null) continue;
-
-            List<ScheduleEntry> currentScheduleList = new ArrayList<>(currentSchedule);
-            if (currentScheduleList.isEmpty()) continue;
-
-            for (ScheduleEntry sc : currentScheduleList) {
-                if (sc.routeId == 0) continue;
-
-                Route route = MtrUtil.getRouteById(sc.routeId);
-
-                List<String> stationNames = new ArrayList<>();
-                Platform currentPlatform = null;
-
-                if (route != null && route.platformIds != null) {
-                    for (Route.RoutePlatform routePlatform : route.platformIds) {
-                        Platform plat = MtrUtil.getPlatformById(routePlatform.platformId);
-                        Station station = MtrUtil.getStationByPlatform(plat);
-
-                        if (station != null) {
-                            stationNames.add(station.name);
-                        }
-
-                        if (routePlatform.platformId == platId) {
-                            currentPlatform = plat;
-                        }
-                    }
-                }
-
-                String destination = MtrUtil.getDestinationByRoute(MtrUtil.getRouteById(sc.routeId));
-                String customDestination =
-                        route != null ? route.getDestination(sc.currentStationIndex) : destination;
-
-                ArrivalInfo info = new ArrivalInfo(
-                        sc.arrivalMillis,
-                        sc.trainCars,
-                        route,
-                        sc.routeId,
-                        sc.currentStationIndex,
-                        destination,
-                        customDestination,
-                        stationNames,
-                        currentPlatform
-                );
-
-                arrivalInfoList.add(info);
-            }
-        }
-
-        arrivalInfoList.sort(Comparator.comparingLong(a -> a.arrivalMillis));
-        return arrivalInfoList;
-    }
-
-    public static final class ArrivalInfo {
-        public final long arrivalMillis;
-        public final int trainCars;
-        public final Route route;
-        public final long routeId;
-        public final int currentStationIndex;
-        public final String destination;
-        public final String customDestination;
-        public final List<String> stationNames;
-        public final Platform currentPlatform;
-
-        public ArrivalInfo(long arrivalMillis,
-                           int trainCars,
-                           Route route,
-                           long routeId,
-                           int currentStationIndex,
-                           String destination,
-                           String customDestination,
-                           List<String> stationNames,
-                           Platform currentPlatform) {
-            this.arrivalMillis = arrivalMillis;
-            this.trainCars = trainCars;
-            this.route = route;
-            this.routeId = routeId;
-            this.currentStationIndex = currentStationIndex;
-            this.destination = destination;
-            this.customDestination = customDestination;
-            this.stationNames = stationNames;
-            this.currentPlatform = currentPlatform;
-        }
-
-        public long arrivalMillis() {
-            return arrivalMillis;
-        }
-
-        public int trainCars() {
-            return trainCars;
-        }
-
-        public Route route() {
-            return route;
-        }
-
-        public long routeId() {
-            return routeId;
-        }
-
-        public int currentStationIndex() {
-            return currentStationIndex;
-        }
-
-        public String destination() {
-            return destination;
-        }
-
-        public String customDestination() {
-            return customDestination;
-        }
-
-        public List<String> stationNames() {
-            return stationNames;
-        }
-
-        public Platform currentPlatform() {
-            return currentPlatform;
-        }
-
-        @Override
-        public boolean equals(Object obj) {
-            if (obj == this) return true;
-            if (obj == null || obj.getClass() != this.getClass()) return false;
-            var that = (ArrivalInfo) obj;
-            return this.arrivalMillis == that.arrivalMillis &&
-                    this.trainCars == that.trainCars &&
-                    Objects.equals(this.route, that.route) &&
-                    this.routeId == that.routeId &&
-                    this.currentStationIndex == that.currentStationIndex &&
-                    Objects.equals(this.destination, that.destination) &&
-                    Objects.equals(this.customDestination, that.customDestination) &&
-                    Objects.equals(this.stationNames, that.stationNames) &&
-                    Objects.equals(this.currentPlatform, that.currentPlatform);
-        }
-
-        @Override
-        public int hashCode() {
-            return Objects.hash(arrivalMillis, trainCars, route, routeId, currentStationIndex, destination, customDestination, stationNames, currentPlatform);
-        }
-
-        @Override
-        public String toString() {
-            return "ArrivalInfo[" +
-                    "arrivalMillis=" + arrivalMillis + ", " +
-                    "trainCars=" + trainCars + ", " +
-                    "route=" + route + ", " +
-                    "routeId=" + routeId + ", " +
-                    "currentStationIndex=" + currentStationIndex + ", " +
-                    "destination=" + destination + ", " +
-                    "customDestination=" + customDestination + ", " +
-                    "stationNames=" + stationNames + ", " +
-                    "currentPlatform=" + currentPlatform + ']';
-        }
-
+    private List<MtrUtil.PidsArrivalInfo> getArrivalInfoList() {
+        return MtrUtil.getPidsArrivalInfoList(plats);
     }
 
     public static final class DrawInfoPids {
-        public final List<ArrivalInfo> arrivalInfoList;
+        public final List<MtrUtil.PidsArrivalInfo> arrivalInfoList;
         public final int[] texArea;
         public final ObjBlockScriptContext ctx;
         public final BlockEntityPids entity;
 
         public DrawInfoPids(
-                List<ArrivalInfo> arrivalInfoList,
+                List<MtrUtil.PidsArrivalInfo> arrivalInfoList,
                 int[] texArea,
                 ObjBlockScriptContext ctx,
                 BlockEntityPids entity
@@ -562,7 +429,7 @@ public class BlockEntityPids extends BaseObjBlockEntity {
             this.entity = entity;
         }
 
-        public List<ArrivalInfo> arrivalInfoList() {
+        public List<MtrUtil.PidsArrivalInfo> arrivalInfoList() {
             return arrivalInfoList;
         }
 

--- a/common/src/main/java/com/fangsu/userScripts/ScriptHolderBase.java
+++ b/common/src/main/java/com/fangsu/userScripts/ScriptHolderBase.java
@@ -117,7 +117,7 @@ public abstract class ScriptHolderBase {
                 TextUtil.hasCjkPart(a[0].asString())
         ));
         b.putMember("hasNonCjkPart", fn(a ->
-                TextUtil.hasCjkPart(a[0].asString())
+                TextUtil.hasNonCjkPart(a[0].asString())
         ));
         b.putMember("loadResource", fn(a ->
                 JsFunctions.loadResource(a[0].asString(), a[1].asString())

--- a/common/src/main/java/com/fangsu/utils/MtrUtil.java
+++ b/common/src/main/java/com/fangsu/utils/MtrUtil.java
@@ -15,8 +15,10 @@ import org.joml.Vector3f;
 import org.joml.Vector3fc;
 
 import java.util.ArrayList;
+import java.util.Comparator;
 import java.util.List;
 import java.util.Map;
+import java.util.Set;
 
 
 public class MtrUtil {
@@ -171,6 +173,66 @@ public class MtrUtil {
             return "undefined";
         }
     }
+
+
+
+    public static List<PidsArrivalInfo> getPidsArrivalInfoList(List<Long> platformIds) {
+        List<PidsArrivalInfo> arrivalInfoList = new ArrayList<>();
+        if (platformIds == null || platformIds.isEmpty()) return arrivalInfoList;
+
+        Map<Long, Set<ScheduleEntry>> scheduleMap = ClientData.SCHEDULES_FOR_PLATFORM;
+        for (Long platformId : platformIds) {
+            if (platformId == null) continue;
+            Set<ScheduleEntry> schedules = scheduleMap.get(platformId);
+            if (schedules == null || schedules.isEmpty()) continue;
+
+            for (ScheduleEntry entry : schedules) {
+                if (entry.routeId == 0) continue;
+                Route route = getRouteById(entry.routeId);
+                if (route == null || route.platformIds == null || route.platformIds.isEmpty()) continue;
+
+                List<String> stationNames = new ArrayList<>();
+                String currentPlatformName = null;
+
+                for (Route.RoutePlatform routePlatform : route.platformIds) {
+                    Platform routePlatformObj = getPlatformById(routePlatform.platformId);
+                    Station station = getStationByPlatform(routePlatformObj);
+                    if (station != null) stationNames.add(station.name);
+                    if (routePlatform.platformId == platformId && routePlatformObj != null) {
+                        currentPlatformName = routePlatformObj.name;
+                    }
+                }
+
+                String destination = getDestinationByRoute(route);
+                String customDestination = route.getDestination(entry.currentStationIndex);
+
+                arrivalInfoList.add(new PidsArrivalInfo(
+                        entry.arrivalMillis,
+                        entry.trainCars,
+                        entry.routeId,
+                        entry.currentStationIndex,
+                        destination,
+                        customDestination,
+                        stationNames,
+                        currentPlatformName
+                ));
+            }
+        }
+
+        arrivalInfoList.sort(Comparator.comparingLong(PidsArrivalInfo::arrivalMillis));
+        return arrivalInfoList;
+    }
+
+    public record PidsArrivalInfo(
+            long arrivalMillis,
+            int trainCars,
+            long routeId,
+            int currentStationIndex,
+            String destination,
+            String customDestination,
+            List<String> stationNames,
+            String currentPlatformName
+    ) {}
 
     /**
      * 坐标转换工具，统一向下取整。

--- a/common/src/main/resources/assets/fangsu/pids/mtr_pids_3a.js
+++ b/common/src/main/resources/assets/fangsu/pids/mtr_pids_3a.js
@@ -1,53 +1,74 @@
-g.setColor(Color.BLACK);
-g.fillRect(drawInfo.texArea[0], drawInfo.texArea[1], drawInfo.texArea[2], drawInfo.texArea[3]);
-if (state.drawBeginTime === undefined || state.drawFlag === undefined) {
-    state.drawBeginTime = Timing.elapsed();
-    state.drawFlag = true;
-}
-var drawTotalTime = 5;
-var font = loadRes(res, "font", "mtrsteamloco:fonts/ae.ttf").deriveFont(15);
-for (var i = 0; i < Math.min(3, arrivalInfoList.length); i++) {
-    g.setColor(Color.WHITE);
-    var arrivingTime = parseInt((arrivalInfoList[i].arrivalMillis - Date.now()) / 1000);
-    if (state.drawFlag) {
-        g.setFont(font);
-        drawTotalTime = Math.max(drawTotalTime, drawScrollText(TextUtil.getCjkParts(arrivalInfoList[i].destination), 128, 4, 20 * (i + 1) + 2, font, state.drawBeginTime));
-        g.drawString(getDispArrival(arrivingTime, true), 250 - g.getFontMetrics(font).stringWidth(getDispArrival(arrivingTime, true)), 20 * (i + 1) + 2);
+var draw = (g, state, drawInfo, extraConfig) => {
+    var arrivalInfoList = drawInfo.arrivalInfoList || [];
+    var texArea = drawInfo.texArea;
+    var width = texArea[2] - texArea[0];
+    var height = texArea[3] - texArea[1];
+
+    g.setColor(Color.BLACK);
+    g.fillRect(texArea[0], texArea[1], texArea[2], texArea[3]);
+
+    if (state.drawBeginTime === undefined) state.drawBeginTime = Timing.elapsed();
+    if (state.drawFlag === undefined) state.drawFlag = true;
+
+    var fontSize = 15;
+    if (state.fontSize !== fontSize || state.font === undefined) {
+        state.fontSize = fontSize;
+        state.font = loadResource("font", "mtrsteamloco:fonts/ae.ttf").deriveFont(fontSize);
     }
-    else {
-        g.setFont(font);
-        drawTotalTime = Math.max(drawTotalTime, drawScrollText(TextUtil.getNonCjkParts(arrivalInfoList[i].destination), 128, 4, 20 * (i + 1) + 2, font, state.drawBeginTime));
-        g.drawString(getDispArrival(arrivingTime, false), 250 - g.getFontMetrics(font).stringWidth(getDispArrival(arrivingTime, false)), 20 * (i + 1) + 2);
-    }
-}
-if (state.drawBeginTime + drawTotalTime < Timing.elapsed()) {
-    state.drawBeginTime = Timing.elapsed();
-    state.drawFlag = !state.drawFlag;
-}
-ctx.setDebugInfo("drawinfo", "drawTotalTime: " + String(drawTotalTime) + " time: " + String(Timing.elapsed()) + " drawBeginTime: " + String(state.drawBeginTime) + " drawFlag: " + String(state.drawFlag))
-function drawScrollText(str, maxX, x, y, font, beginTime) {
+
+    var font = state.font;
     g.setFont(font);
-    if (g.getFontMetrics(font).stringWidth(str) <= maxX) {
-        g.drawString(str, x, y);
-        return 0;
+    var metrics = g.getFontMetrics(font);
+    var drawTotalTime = 5;
+    var textRight = Math.max(0, width - 6);
+
+    for (var i = 0; i < Math.min(3, arrivalInfoList.length); i++) {
+        var arrivalInfo = arrivalInfoList[i];
+        if (!arrivalInfo) continue;
+
+        var arrivingTime = parseInt((arrivalInfo.arrivalMillis - Date.now()) / 1000);
+        var isCjkPage = state.drawFlag;
+        var destination = isCjkPage ? TextUtil.getCjkParts(arrivalInfo.destination) : TextUtil.getNonCjkParts(arrivalInfo.destination);
+        if (!destination || destination.length === 0) {
+            destination = arrivalInfo.destination;
+        }
+
+        g.setColor(Color.WHITE);
+        var y = 20 * (i + 1) + 2;
+        drawTotalTime = Math.max(drawTotalTime, drawScrollText(destination, 128, 4, y, metrics, state.drawBeginTime));
+
+        var arrivalText = getDispArrival(arrivingTime, isCjkPage);
+        g.drawString(arrivalText, textRight - metrics.stringWidth(arrivalText), y);
     }
-    var originalClip = g.getClip();
-    var totalTextLeng = g.getFontMetrics(font).stringWidth(str) + maxX;
-    var speed = maxX * 0.25;
-    var totalTime = parseInt(totalTextLeng / speed);
-    g.setClip(new java.awt.Rectangle(x, y - g.getFontMetrics(font).getHeight() - 2, maxX, g.getFontMetrics(font).getHeight() + 4));
-    g.drawString(str, x + maxX - (Timing.elapsed() - beginTime - 0.1) % totalTime * speed, y);
-    g.setClip(originalClip);
-    return totalTime;
-}
-function getDispArrival(time, flag) {
-    if (time <= 2)
-        return flag ? "已经到达" : "Arrived";
-    else if (time <= 20)
-        return flag ? "即将进站" : "Arriving";
-    else if (time <= 60)
-        return String(time) + (flag ? " 秒" : " sec");
-    else if (time <= 3600)
-        return String(parseInt(time / 60)) + (flag ? " 分" : " min");
-    return String(parseInt(time / 3600)) + (flag ? " 时" : " hour");
-}
+
+    if (state.drawBeginTime + drawTotalTime < Timing.elapsed()) {
+        state.drawBeginTime = Timing.elapsed();
+        state.drawFlag = !state.drawFlag;
+    }
+
+    function drawScrollText(str, maxX, x, y, metrics, beginTime) {
+        var textWidth = metrics.stringWidth(str);
+        if (textWidth <= maxX) {
+            g.drawString(str, x, y);
+            return 0;
+        }
+
+        var originalClip = g.getClip();
+        var totalTextLength = textWidth + maxX;
+        var speed = maxX * 0.25;
+        var totalTime = Math.max(1, parseInt(totalTextLength / speed));
+
+        g.setClip(new Rectangle(x, y - metrics.getHeight() - 2, maxX, metrics.getHeight() + 4));
+        g.drawString(str, x + maxX - ((Timing.elapsed() - beginTime - 0.1) % totalTime) * speed, y);
+        g.setClip(originalClip);
+        return totalTime;
+    }
+
+    function getDispArrival(time, flag) {
+        if (time <= 2) return flag ? "已经到达" : "Arrived";
+        if (time <= 20) return flag ? "即将进站" : "Arriving";
+        if (time <= 60) return String(time) + (flag ? " 秒" : " sec");
+        if (time <= 3600) return String(parseInt(time / 60)) + (flag ? " 分" : " min");
+        return String(parseInt(time / 3600)) + (flag ? " 时" : " hour");
+    }
+};

--- a/common/src/main/resources/assets/fangsu/pids/mtr_pids_3b.js
+++ b/common/src/main/resources/assets/fangsu/pids/mtr_pids_3b.js
@@ -1,50 +1,60 @@
 var draw = (g, state, drawInfo, extraConfig) => {
-    // setDebugInfo(`"drawInfo =", ${drawInfo}`);
-    // setDebugInfo(`"keys =", ${Object.keys(drawInfo)}`);
-    // setDebugInfo(`"texArea =", ${drawInfo.texArea}`);
-    // setDebugInfo(`"textArea =", ${drawInfo.textArea}`);
+    var arrivalInfoList = drawInfo.arrivalInfoList || [];
+    var texArea = drawInfo.texArea;
+    var width = texArea[2] - texArea[0];
+    var height = texArea[3] - texArea[1];
 
-    var arrivalInfoList = drawInfo.arrivalInfoList;
-    g.setColor(rgbToColor(0, 0, 0));
-    g.fillRect(drawInfo.texArea[0], drawInfo.texArea[1], drawInfo.texArea[2], drawInfo.texArea[3]);
-    if (state.drawBeginTime === undefined || state.drawFlag === undefined) {
-        state.drawBeginTime = Timing.elapsed();
-        state.drawFlag = true;
+    g.setColor(Color.BLACK);
+    g.fillRect(texArea[0], texArea[1], texArea[2], texArea[3]);
+
+    if (state.drawBeginTime === undefined) state.drawBeginTime = Timing.elapsed();
+    if (state.drawFlag === undefined) state.drawFlag = true;
+    if (state.fontSize !== height * 0.25 || state.font === undefined) {
+        state.fontSize = height * 0.25;
+        state.font = loadResource("font", "mtrsteamloco:fonts/ae.ttf").deriveFont(state.fontSize);
     }
-    var w = drawInfo.texArea[2] - drawInfo.texArea[0];
-    var h = drawInfo.texArea[3] - drawInfo.texArea[1];
+
     var drawTotalTime = 5;
-    var font = loadResource("font", "mtrsteamloco:fonts/ae.ttf").deriveFont(h * 0.25);
+    var font = state.font;
+    g.setFont(font);
+    var metrics = g.getFontMetrics(font);
+    var textRight = Math.max(0, width - 6);
+
     for (var i = 0; i < Math.min(2, arrivalInfoList.length); i++) {
-        g.setColor(Color.WHITE);
-        var arrivingTime = parseInt((arrivalInfoList[i].arrivalMillis - Date.now()) / 1000);
-        g.setColor(arrivingTime <= 20 ? rgbToColor(17, 170, 56) : rgbToColor(230, 91, 0));
-        if ((state.drawFlag && hasCjkPart(arrivalInfoList[i].destination)) || (!state.drawFlag && !hasNonCjkPart(arrivalInfoList[i].destination))) {
-            g.setFont(font);
-            drawTotalTime = Math.max(drawTotalTime, drawScrollText(TextUtil.getCjkParts(arrivalInfoList[i].destination), 128, 4, h * 0.4 * (i + 1) + 2, font, state.drawBeginTime));
-            g.drawString(getDispArrival(arrivingTime, true), 250 - g.getFontMetrics(font).stringWidth(getDispArrival(arrivingTime, true)), h * 0.4 * (i + 1) + 2);
-        } else {
-            g.setFont(font);
-            drawTotalTime = Math.max(drawTotalTime, drawScrollText(TextUtil.getNonCjkParts(arrivalInfoList[i].destination), 128, 4, h * 0.4 * (i + 1) + 2, font, state.drawBeginTime));
-            g.drawString(getDispArrival(arrivingTime, false), 250 - g.getFontMetrics(font).stringWidth(getDispArrival(arrivingTime, false)), h * 0.4 * (i + 1) + 2);
+        var arrivalInfo = arrivalInfoList[i];
+        if (!arrivalInfo) continue;
+
+        var arrivingTime = parseInt((arrivalInfo.arrivalMillis - Date.now()) / 1000);
+        var isCjkPage = state.drawFlag;
+        var destination = isCjkPage ? TextUtil.getCjkParts(arrivalInfo.destination) : TextUtil.getNonCjkParts(arrivalInfo.destination);
+        if (!destination || destination.length === 0) {
+            destination = arrivalInfo.destination;
         }
+
+        g.setColor(arrivingTime <= 20 ? rgbToColor(17, 170, 56) : rgbToColor(230, 91, 0));
+        var y = height * 0.4 * (i + 1) + 2;
+        drawTotalTime = Math.max(drawTotalTime, drawScrollText(destination, 128, 4, y, metrics, state.drawBeginTime));
+
+        var arrivalText = getDispArrival(arrivingTime, isCjkPage);
+        g.drawString(arrivalText, textRight - metrics.stringWidth(arrivalText), y);
     }
+
     if (state.drawBeginTime + drawTotalTime < Timing.elapsed()) {
         state.drawBeginTime = Timing.elapsed();
         state.drawFlag = !state.drawFlag;
     }
 
-    function drawScrollText(str, maxX, x, y, font, beginTime) {
-        g.setFont(font);
-        if (g.getFontMetrics(font).stringWidth(str) <= maxX) {
+    function drawScrollText(str, maxX, x, y, metrics, beginTime) {
+        var textWidth = metrics.stringWidth(str);
+        if (textWidth <= maxX) {
             g.drawString(str, x, y);
             return 0;
         }
         var originalClip = g.getClip();
-        var totalTextLeng = g.getFontMetrics(font).stringWidth(str) + maxX;
+        var totalTextLength = textWidth + maxX;
         var speed = maxX * 0.25;
-        var totalTime = parseInt(totalTextLeng / speed);
-        g.setClip(new java.awt.Rectangle(x, y - g.getFontMetrics(font).getHeight() - 2, maxX, g.getFontMetrics(font).getHeight() + 4));
+        var totalTime = Math.max(1, parseInt(totalTextLength / speed));
+        g.setClip(new Rectangle(x, y - metrics.getHeight() - 2, maxX, metrics.getHeight() + 4));
         g.drawString(str, x + maxX - ((Timing.elapsed() - beginTime - 0.1) % totalTime) * speed, y);
         g.setClip(originalClip);
         return totalTime;
@@ -52,9 +62,9 @@ var draw = (g, state, drawInfo, extraConfig) => {
 
     function getDispArrival(time, flag) {
         if (time <= 2) return flag ? "已经到达" : "Arrived";
-        else if (time <= 20) return flag ? "即将进站" : "Arriving";
-        else if (time <= 60) return String(time) + (flag ? " 秒" : " sec");
-        else if (time <= 3600) return String(parseInt(time / 60)) + (flag ? " 分" : " min");
+        if (time <= 20) return flag ? "即将进站" : "Arriving";
+        if (time <= 60) return String(time) + (flag ? " 秒" : " sec");
+        if (time <= 3600) return String(parseInt(time / 60)) + (flag ? " 分" : " min");
         return String(parseInt(time / 3600)) + (flag ? " 时" : " hour");
     }
 };

--- a/common/src/main/resources/assets/fangsu/pids/mtr_pids_4b.js
+++ b/common/src/main/resources/assets/fangsu/pids/mtr_pids_4b.js
@@ -1,71 +1,87 @@
 var draw = (g, state, drawInfo, extraConfig) => {
-    var arrivalInfoList = drawInfo.arrivalInfoList;
+    var arrivalInfoList = drawInfo.arrivalInfoList || [];
+    var texArea = drawInfo.texArea;
+    var width = texArea[2] - texArea[0];
+    var height = texArea[3] - texArea[1];
+
     g.setColor(Color.BLACK);
-    g.fillRect(drawInfo.texArea[0], drawInfo.texArea[1], drawInfo.texArea[2], drawInfo.texArea[3]);
+    g.fillRect(texArea[0], texArea[1], texArea[2], texArea[3]);
+
     if (state.drawBeginTime === undefined) state.drawBeginTime = Timing.elapsed();
     if (state.drawFlag === undefined) state.drawFlag = true;
     if (state.page === undefined) state.page = 1;
-    var w = drawInfo.texArea[2] - drawInfo.texArea[0];
-    var h = drawInfo.texArea[3] - drawInfo.texArea[1];
-    var drawTotalTime = 5;
-    var font = loadResource("font", "mtrsteamloco:fonts/ae.ttf").deriveFont(h * 0.05);
-    var lineHeight = h / 17;
+
+    var fontSize = height * 0.05;
+    if (state.fontSize !== fontSize || state.font === undefined) {
+        state.fontSize = fontSize;
+        state.font = loadResource("font", "mtrsteamloco:fonts/ae.ttf").deriveFont(fontSize);
+    }
+
+    var font = state.font;
+    g.setFont(font);
+    var metrics = g.getFontMetrics(font);
+
+    var lineHeight = height / 17;
     var beginHeight = lineHeight * 0.25;
     var beginWidth = beginHeight;
-    var endHeight = h - beginHeight;
-    var endWidth = w - beginWidth;
-    g.setFont(font);
+    var endWidth = width - beginWidth;
+
     g.setColor(rgbToColor(252, 151, 0));
     var arrivalInfo = arrivalInfoList[0];
     if (!arrivalInfo) return;
+
     var arrivingTime = parseInt((arrivalInfo.arrivalMillis - Date.now()) / 1000);
-    var forwardStations = arrivalInfo.stationNames.slice(arrivalInfo.currentStationIndex);
-    var pages = Math.ceil(forwardStations.length / 11);
+    var forwardStations = (arrivalInfo.stationNames || []).slice(arrivalInfo.currentStationIndex);
+    var pages = Math.max(1, Math.ceil(forwardStations.length / 11));
+    if (state.page > pages) state.page = 1;
 
     drawStrUnified(g, font, getDispArrival(arrivingTime, state.drawFlag), beginWidth, lineHeight + beginHeight, lineHeight * 0.8, 0);
-    drawStrUnified(g, font, state.drawFlag ? arrivalInfo.currentPlatform.name + "站台" : "Plat. " + arrivalInfo.currentPlatform.name, endWidth, lineHeight + beginHeight, lineHeight * 0.8, 2);
-    drawStrUnified(g, font, getMatching(arrivalInfo.costomDestination || arrivalInfo.destination, state.drawFlag), beginWidth, lineHeight * 2 + beginHeight, lineHeight * 0.8, 0);
-    drawStrUnified(g, font, getMatching("停靠站：|Stops At:", state.drawFlag) + ("(" + state.page + "/" + pages + ")"), beginWidth, lineHeight * 4 + beginHeight, lineHeight * 0.8, 0);
+    var platformName = arrivalInfo.currentPlatformName || "-";
+    drawStrUnified(g, font, state.drawFlag ? platformName + "站台" : "Plat. " + platformName, endWidth, lineHeight + beginHeight, lineHeight * 0.8, 2);
+    drawStrUnified(g, font, getMatching(arrivalInfo.customDestination || arrivalInfo.destination, state.drawFlag), beginWidth, lineHeight * 2 + beginHeight, lineHeight * 0.8, 0);
+    drawStrUnified(g, font, getMatching("停靠站：|Stops At:", state.drawFlag) + "(" + state.page + "/" + pages + ")", beginWidth, lineHeight * 4 + beginHeight, lineHeight * 0.8, 0);
 
-    for (var i = 0; i < Math.min(11, forwardStations.length - (state.page - 1) * 11); i++) {
-        var thisTime = drawScrollText(
-            getMatching(forwardStations[i + (state.page - 1) * 11], state.drawFlag),
-            w - beginWidth * 2,
-            beginWidth,
-            lineHeight * (5 + i) + beginHeight,
-            font,
-            state.drawBeginTime
-        );
-        drawTotalTime = Math.max(drawTotalTime, thisTime);
+    var drawTotalTime = 5;
+    var offset = (state.page - 1) * 11;
+    for (var i = 0; i < Math.min(11, forwardStations.length - offset); i++) {
+        var stationName = getMatching(forwardStations[i + offset], state.drawFlag);
+        drawTotalTime = Math.max(drawTotalTime, drawScrollText(stationName, width - beginWidth * 2, beginWidth, lineHeight * (5 + i) + beginHeight, metrics, state.drawBeginTime));
     }
+
     if (state.drawBeginTime + drawTotalTime < Timing.elapsed()) {
         state.drawBeginTime = Timing.elapsed();
-        if (state.page < pages) state.page++;
-        else state.drawFlag = !state.drawFlag;
+        if (state.page < pages) {
+            state.page++;
+        } else {
+            state.page = 1;
+            state.drawFlag = !state.drawFlag;
+        }
     }
+
     g.setColor(Color.RED);
     drawStrUnified(g, font, state.drawFlag ? arrivalInfo.trainCars + " 节" : arrivalInfo.trainCars + "-car", endWidth, lineHeight * 16 + beginHeight, lineHeight * 0.8, 2);
 
-    function drawScrollText(str, maxX, x, y, font, beginTime) {
-        g.setFont(font);
-        if (g.getFontMetrics(font).stringWidth(str) <= maxX) {
+    function drawScrollText(str, maxX, x, y, metrics, beginTime) {
+        var textWidth = metrics.stringWidth(str);
+        if (textWidth <= maxX) {
             g.drawString(str, x, y);
             return 0;
         }
         var originalClip = g.getClip();
-        var totalTextLeng = g.getFontMetrics(font).stringWidth(str) + maxX;
+        var totalTextLength = textWidth + maxX;
         var speed = maxX * 0.25;
-        var totalTime = parseInt(totalTextLeng / speed);
-        g.setClip(new java.awt.Rectangle(x, y - g.getFontMetrics(font).getHeight() - 2, maxX, g.getFontMetrics(font).getHeight() + 4));
+        var totalTime = Math.max(1, parseInt(totalTextLength / speed));
+        g.setClip(new Rectangle(x, y - metrics.getHeight() - 2, maxX, metrics.getHeight() + 4));
         g.drawString(str, x + maxX - ((Timing.elapsed() - beginTime - 0.1) % totalTime) * speed, y);
         g.setClip(originalClip);
         return totalTime;
     }
+
     function getDispArrival(time, flag) {
         if (time <= 2) return flag ? "已经到达" : "Arrived";
-        else if (time <= 20) return flag ? "即将进站" : "Arriving";
-        else if (time <= 60) return String(time) + (flag ? " 秒" : " sec");
-        else if (time <= 3600) return String(parseInt(time / 60)) + (flag ? " 分" : " min");
+        if (time <= 20) return flag ? "即将进站" : "Arriving";
+        if (time <= 60) return String(time) + (flag ? " 秒" : " sec");
+        if (time <= 3600) return String(parseInt(time / 60)) + (flag ? " 分" : " min");
         return String(parseInt(time / 3600)) + (flag ? " 时" : " hour");
     }
 };


### PR DESCRIPTION
### Motivation

- Prevent blocking main thread while initializing user PIDS scripts and ensure draw graphics are removed when a block entity is disposed. 
- Standardize arrival info representation and simplify PIDS logic by extracting schedule parsing into a utility.
- Fix a small JavaScript/utility bug and harden scripts to handle missing/empty data and variable texture sizes.

### Description

- Added a `disposed` flag, `whenDisposing()` hook, and overrides for `setRemoved()`/`clearRemoved()` in `BaseObjBlockEntity` to run disposal logic when block entities are removed or restored.
- In `BlockEntityPids` introduced an executor `PIDS_SCRIPT_EXECUTOR`, a `scriptLoadToken` to avoid races, and moved script holder initialization into `initScriptDrawingAsync()` using `CompletableFuture` so script loading runs off the main thread, while texture draw registration is created immediately.
- Implemented `whenDisposing()` in `BlockEntityPids` to cancel pending loads, clear draw state and remove graphics (`GraphicsTextureHelper.removeDrawGraphic`).
- Replaced the ad-hoc `ArrivalInfo` with `MtrUtil.PidsArrivalInfo` and delegated schedule parsing to `MtrUtil.getPidsArrivalInfoList()` which returns a sorted list of arrival records.
- Fixed a logic typo in `ScriptHolderBase` where `hasNonCjkPart` previously called `hasCjkPart`, and kept small imports/additions for concurrency classes.
- Updated several PIDS JavaScript assets to a unified `draw` function form, added defensive handling for empty lists, computed font/metrics once per state, improved scrolling clip handling, paging behavior, and localized arrival display formatting.

### Testing

- Built the project using the standard Gradle Java compile step (`./gradlew :common:compileJava`) and the compilation succeeded.
- No automated unit tests were present for the modified behavior; the change was covered by the compile check above.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69a42ca6ddb8832e8c01a89d312be4cd)