### PR TITLE
Centralize Graal VM Context and refactor script holder lifecycle

### DIFF
--- a/common/src/main/java/com/fangsu/blockEntities/BlockEntityPids.java
+++ b/common/src/main/java/com/fangsu/blockEntities/BlockEntityPids.java
@@ -50,7 +50,7 @@ public class BlockEntityPids extends BaseObjBlockEntity {
     private CollisionBoxUtil.CollisionBox shape;
     private Map<String, JsonElement> userExtraConfigs;
 
-    private ScriptHolderBase scriptHolder;
+    private volatile ScriptHolderBase scriptHolder;
     private Map<String, Map<String, Object>> loaded;
     private int texW, texH;
     private Map<String, Object> drawState = new HashMap<>();
@@ -150,7 +150,6 @@ public class BlockEntityPids extends BaseObjBlockEntity {
         gtHelper.removeDrawGraphic(getBlockPos());
 
         final int thisLoadToken = ++scriptLoadToken;
-        scriptHolder = null;
 
         String scriptPath = (String) current.get("script");
         ResourceLocation location = new ResourceLocation(scriptPath);
@@ -176,9 +175,7 @@ public class BlockEntityPids extends BaseObjBlockEntity {
 
         CompletableFuture.runAsync(() -> {
             try {
-                ScriptManager manager = ScriptManager.getInstance();
-                manager.initHolder(location, PidsScriptHolder::new);
-                ScriptHolderBase loadedHolder = manager.getHolder(location);
+                ScriptHolderBase loadedHolder = ScriptManager.getInstance().getOrInitHolder(location, PidsScriptHolder::new);
                 if (loadedHolder != null && thisLoadToken == scriptLoadToken) {
                     scriptHolder = loadedHolder;
                 }

--- a/common/src/main/java/com/fangsu/userScripts/PidsScriptHolder.java
+++ b/common/src/main/java/com/fangsu/userScripts/PidsScriptHolder.java
@@ -1,8 +1,10 @@
 package com.fangsu.userScripts;
 
+import org.graalvm.polyglot.Context;
+
 public class PidsScriptHolder extends ScriptHolderBase {
     @Override
-    protected void init() {
-        loadFunction("draw");
+    protected void init(Context context) {
+        loadFunction(context, "draw");
     }
 }

--- a/common/src/main/java/com/fangsu/userScripts/ScriptHolderBase.java
+++ b/common/src/main/java/com/fangsu/userScripts/ScriptHolderBase.java
@@ -1,50 +1,32 @@
 package com.fangsu.userScripts;
 
 import com.fangsu.Main;
-import com.fangsu.scripting.JsFunctions;
-import com.fangsu.scripting.TextUtil;
-import com.fangsu.scripting.TimingUtil;
 import com.fangsu.utils.ResourceUtil;
-import org.graalvm.polyglot.*;
 import net.minecraft.resources.ResourceLocation;
-import org.graalvm.polyglot.proxy.ProxyExecutable;
-import org.graalvm.polyglot.proxy.ProxyObject;
+import org.graalvm.polyglot.Context;
+import org.graalvm.polyglot.Source;
+import org.graalvm.polyglot.Value;
 
-import java.util.*;
+import java.util.HashMap;
+import java.util.Map;
 
 public abstract class ScriptHolderBase {
 
-    protected Context context;
-    protected Map<String, Value> functions = new HashMap<>();
+    protected final Map<String, Value> functions = new HashMap<>();
     protected String scriptName;
 
-    public Map<String, Long> failTime = new HashMap<>();
-
-    protected ScriptHolderBase() {
-        context = Context.newBuilder("js")
-                .allowExperimentalOptions(true)
-                .option("js.nashorn-compat", "true")
-                .option("js.ecmascript-version", "2020")
-                .allowHostClassLookup(c -> true)
-                .allowHostAccess(HostAccess.ALL)
-                .allowCreateThread(true)
-                .build();
-
-        Value bindings = context.getBindings("js");
-        setBuiltInFunction(context, bindings);
-        injectJsFunctions(context);
-    }
+    public final Map<String, Long> failTime = new HashMap<>();
 
     /**
      * 加载脚本内容
      */
-    public void loadScript(ResourceLocation location) {
+    public synchronized void loadScript(Context context, ResourceLocation location) {
         scriptName = location.toString();
         try {
             String script = ResourceUtil.loadString(location);
-
+            functions.clear();
             context.eval(Source.newBuilder("js", script, location.toString()).buildLiteral());
-            init(); // 子类负责注册函数}
+            init(context); // 子类负责注册函数
         } catch (Exception e) {
             Main.LOGGER.error("Error loading script {} : {}", location, e.getMessage());
             Main.LOGGER.error("Stacktrace:");
@@ -57,12 +39,12 @@ public abstract class ScriptHolderBase {
     /**
      * 子类实现：注册需要的 JS 函数
      */
-    protected abstract void init();
+    protected abstract void init(Context context);
 
     /**
      * 注册 JS 函数到 Map
      */
-    protected void loadFunction(String name) {
+    protected void loadFunction(Context context, String name) {
         Value fn = context.getBindings("js").getMember(name);
         if (fn != null && fn.canExecute()) {
             functions.put(name, fn);
@@ -72,7 +54,7 @@ public abstract class ScriptHolderBase {
     /**
      * 执行 JS 函数
      */
-    public void runFunction(String name, Object... params) {
+    public synchronized void runFunction(String name, Object... params) {
         if (duringFailTimeout(name)) return;
         Value fn = functions.get(name);
         if (fn != null) {
@@ -89,84 +71,9 @@ public abstract class ScriptHolderBase {
         }
     }
 
-    public void close() {
-        if (context != null) {
-            context.close();
-            context = null;
-        }
-    }
-
-    private static void setBuiltInFunction(Context ctx, Value b) {
-        b.putMember("Color", java.awt.Color.class);
-        b.putMember("Font", java.awt.Font.class);
-        b.putMember("BasicStroke", java.awt.BasicStroke.class);
-        b.putMember("RenderingHints", java.awt.RenderingHints.class);
-        b.putMember("Rectangle", java.awt.Rectangle.class);
-
-//        inject(ctx, TimingUtil.class, "Timing");
-        b.putMember("Timing",
-                JsStaticBridge.fromStaticClass(TimingUtil.class));
-        b.putMember("TextUtil",
-                JsStaticBridge.fromStaticClass(TextUtil.class));
-//        inject(ctx, TextUtil.class, "TextUtil");
-
-        b.putMember("getMatching", fn(a ->
-                TextUtil.getCjkMatching(a[0].asString(), a[1].asBoolean())
-        ));
-        b.putMember("hasCjkPart", fn(a ->
-                TextUtil.hasCjkPart(a[0].asString())
-        ));
-        b.putMember("hasNonCjkPart", fn(a ->
-                TextUtil.hasNonCjkPart(a[0].asString())
-        ));
-        b.putMember("loadResource", fn(a ->
-                JsFunctions.loadResource(a[0].asString(), a[1].asString())
-        ));
-        b.putMember("addPrefix", fn(a ->
-                JsFunctions.addPrefix(a[0].asString(), a[1].asString(), a[2].asBoolean())
-        ));
-        b.putMember("addSuffix", fn(a ->
-                JsFunctions.addSuffix(a[0].asString(), a[1].asString())
-        ));
-        b.putMember("setDebugInfo", fn(a -> {
-            JsFunctions.setDebugInfo(a[0].asString());
-            return null;
-        }));
-        b.putMember("setWarnInfo", fn(a -> {
-            JsFunctions.setWarnInfo(a[0].asString());
-            return null;
-        }));
-        b.putMember("setErrorInfo", fn(a -> {
-            JsFunctions.setErrorInfo(a[0].asString());
-            return null;
-        }));
-        b.putMember("getCurrentDate", fn(a -> JsFunctions.getCurrentDate()));
-        b.putMember("getCurrentWeekday", fn(a -> JsFunctions.getCurrentWeekday()));
-        b.putMember("formatDate", fn(a -> JsFunctions.formatDate(a[0].asBoolean())));
-        b.putMember("formatWeekday", fn(a -> JsFunctions.formatWeekday(a[0].asBoolean())));
-        b.putMember("rgbToColor", fn(a ->
-                JsFunctions.rgbToColor(a[0].asInt(), a[1].asInt(), a[2].asInt())
-        ));
-        b.putMember("rgbaToColor", fn(a ->
-                JsFunctions.rgbaToColor(a[0].asInt(), a[1].asInt(), a[2].asInt(), a[3].asInt())
-        ));
-        b.putMember("intToColor", fn(a ->
-                JsFunctions.intToColor(a[0].asInt())
-        ));
-        b.putMember("isLightColor", fn(a ->
-                JsFunctions.isLightColor((java.awt.Color) a[0].asHostObject())
-        ));
-
-    }
-
-    private static ProxyExecutable fn(JsFunc f) {
-        return args -> {
-            try {
-                return f.call(args);
-            } catch (Exception e) {
-                throw new RuntimeException(e);
-            }
-        };
+    public synchronized void close() {
+        functions.clear();
+        failTime.clear();
     }
 
     @FunctionalInterface
@@ -178,20 +85,4 @@ public abstract class ScriptHolderBase {
         Long t = failTime.get(name);
         return t != null && (System.currentTimeMillis() - t) < 4000;
     }
-
-    protected static void inject(Context context, Class clazz, String alias) {
-        if (alias == null) alias = clazz.getSimpleName();
-        context.eval("js", "var " + alias + " = () => Java.type('" + clazz.getName() + "');");
-    }
-
-    protected static void inject(Context context, String key, String value) {
-        context.eval("js", "var " + key + " = '" + value + "';");
-    }
-
-    private static void injectJsFunctions(Context context) {
-        String jsFunctions = """
-                """;
-        context.eval("js", jsFunctions);
-    }
-
 }

--- a/common/src/main/java/com/fangsu/userScripts/ScriptManager.java
+++ b/common/src/main/java/com/fangsu/userScripts/ScriptManager.java
@@ -1,31 +1,117 @@
 package com.fangsu.userScripts;
 
+import com.fangsu.scripting.JsFunctions;
+import com.fangsu.scripting.TextUtil;
+import com.fangsu.scripting.TimingUtil;
 import net.minecraft.resources.ResourceLocation;
+import org.graalvm.polyglot.Context;
+import org.graalvm.polyglot.Value;
+import org.graalvm.polyglot.proxy.ProxyExecutable;
 
 import java.util.HashMap;
 import java.util.Map;
 import java.util.function.Supplier;
 
 public class ScriptManager {
-    private static final ScriptManager instance = new ScriptManager();
-    private Map<ResourceLocation, ScriptHolderBase> holders;
+
+    private static final ScriptManager INSTANCE = new ScriptManager();
+
+    private final Context context;
+    private final Map<ResourceLocation, ScriptHolderBase> holders;
 
     private ScriptManager() {
+        context = Context.newBuilder("js")
+                .allowExperimentalOptions(true)
+                .option("js.nashorn-compat", "true")
+                .option("js.ecmascript-version", "2020")
+                .allowHostClassLookup(c -> true)
+                .allowHostAccess(org.graalvm.polyglot.HostAccess.ALL)
+                .allowCreateThread(true)
+                .build();
+
+        Value bindings = context.getBindings("js");
+        setBuiltInFunction(bindings);
+        injectJsFunctions(context);
+
         holders = new HashMap<>();
     }
 
     public static ScriptManager getInstance() {
-        return instance;
+        return INSTANCE;
     }
 
-    public ScriptHolderBase getHolder(ResourceLocation id) {
+    public synchronized ScriptHolderBase getHolder(ResourceLocation id) {
         return holders.getOrDefault(id, null);
     }
 
-    public void initHolder(ResourceLocation pos, Supplier<? extends ScriptHolderBase> holderSupplier) throws Exception {
+    public synchronized void initHolder(ResourceLocation pos, Supplier<? extends ScriptHolderBase> holderSupplier) {
         if (holders.containsKey(pos)) return;
         ScriptHolderBase holder = holderSupplier.get();
-        holder.loadScript(pos);
+        holder.loadScript(context, pos);
         holders.put(pos, holder);
+    }
+
+    public synchronized ScriptHolderBase getOrInitHolder(ResourceLocation pos, Supplier<? extends ScriptHolderBase> holderSupplier) {
+        ScriptHolderBase holder = holders.get(pos);
+        if (holder == null) {
+            holder = holderSupplier.get();
+            holder.loadScript(context, pos);
+            holders.put(pos, holder);
+        }
+        return holder;
+    }
+
+    private static void setBuiltInFunction(Value b) {
+        b.putMember("Color", java.awt.Color.class);
+        b.putMember("Font", java.awt.Font.class);
+        b.putMember("BasicStroke", java.awt.BasicStroke.class);
+        b.putMember("RenderingHints", java.awt.RenderingHints.class);
+        b.putMember("Rectangle", java.awt.Rectangle.class);
+
+        b.putMember("Timing", JsStaticBridge.fromStaticClass(TimingUtil.class));
+        b.putMember("TextUtil", JsStaticBridge.fromStaticClass(TextUtil.class));
+
+        b.putMember("getMatching", fn(a -> TextUtil.getCjkMatching(a[0].asString(), a[1].asBoolean())));
+        b.putMember("hasCjkPart", fn(a -> TextUtil.hasCjkPart(a[0].asString())));
+        b.putMember("hasNonCjkPart", fn(a -> TextUtil.hasNonCjkPart(a[0].asString())));
+        b.putMember("loadResource", fn(a -> JsFunctions.loadResource(a[0].asString(), a[1].asString())));
+        b.putMember("addPrefix", fn(a -> JsFunctions.addPrefix(a[0].asString(), a[1].asString(), a[2].asBoolean())));
+        b.putMember("addSuffix", fn(a -> JsFunctions.addSuffix(a[0].asString(), a[1].asString())));
+        b.putMember("setDebugInfo", fn(a -> {
+            JsFunctions.setDebugInfo(a[0].asString());
+            return null;
+        }));
+        b.putMember("setWarnInfo", fn(a -> {
+            JsFunctions.setWarnInfo(a[0].asString());
+            return null;
+        }));
+        b.putMember("setErrorInfo", fn(a -> {
+            JsFunctions.setErrorInfo(a[0].asString());
+            return null;
+        }));
+        b.putMember("getCurrentDate", fn(a -> JsFunctions.getCurrentDate()));
+        b.putMember("getCurrentWeekday", fn(a -> JsFunctions.getCurrentWeekday()));
+        b.putMember("formatDate", fn(a -> JsFunctions.formatDate(a[0].asBoolean())));
+        b.putMember("formatWeekday", fn(a -> JsFunctions.formatWeekday(a[0].asBoolean())));
+        b.putMember("rgbToColor", fn(a -> JsFunctions.rgbToColor(a[0].asInt(), a[1].asInt(), a[2].asInt())));
+        b.putMember("rgbaToColor", fn(a -> JsFunctions.rgbaToColor(a[0].asInt(), a[1].asInt(), a[2].asInt(), a[3].asInt())));
+        b.putMember("intToColor", fn(a -> JsFunctions.intToColor(a[0].asInt())));
+        b.putMember("isLightColor", fn(a -> JsFunctions.isLightColor((java.awt.Color) a[0].asHostObject())));
+    }
+
+    private static ProxyExecutable fn(ScriptHolderBase.JsFunc f) {
+        return args -> {
+            try {
+                return f.call(args);
+            } catch (Exception e) {
+                throw new RuntimeException(e);
+            }
+        };
+    }
+
+    private static void injectJsFunctions(Context context) {
+        String jsFunctions = """
+                """;
+        context.eval("js", jsFunctions);
     }
 }


### PR DESCRIPTION
### Motivation
- Simplify and centralize JavaScript execution environment by moving Graal `Context` creation and built-in injections into a single manager. 
- Reduce per-holder Context management and make script holder lifecycle and loading safer for concurrent access. 
- Ensure safe asynchronous script loading and execution from block entities while avoiding repeated Context initialization.

### Description
- Move Graal `Context` to `ScriptManager` as a singleton field and create the shared Context with built-in functions via `setBuiltInFunction` and `injectJsFunctions`.
- Change `ScriptHolderBase` API to no longer own a `Context`: `loadScript` and `init` now accept a `Context` parameter, `loadFunction` accepts a `Context`, `runFunction` is synchronized, and `close` clears internal maps instead of closing a Context.
- Add `ScriptManager.getOrInitHolder` to atomically obtain or initialize a `ScriptHolderBase`, and update `initHolder`/`getHolder` to be synchronized.
- Update `PidsScriptHolder` to match the new API by implementing `init(Context)` and calling `loadFunction(context, "draw")`.
- Update `BlockEntityPids` to use `ScriptManager.getOrInitHolder(...)` for async script loading, make `scriptHolder` volatile, and keep the `scriptLoadToken` mechanism for safe async replacements of the holder.
- Minor concurrency and cleanup changes: `functions`, `failTime` handling, and method synchronization to improve thread-safety during script loading and execution.

### Testing
- Performed a full project compilation (`./gradlew build`) after changes and the build completed successfully.
- No new automated unit tests were added in this change set and existing test suites were not modified.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69a43c79bb8c832ea8405bb776ad20b4)