### PR TITLE
Centralize content loading and model selection helpers; deduplicate transform/selection logic

### DIFF
--- a/common/src/main/java/com/fangsu/blockEntities/BaseObjBlockEntity.java
+++ b/common/src/main/java/com/fangsu/blockEntities/BaseObjBlockEntity.java
@@ -2,6 +2,7 @@ package com.fangsu.blockEntities;
 
 import com.fangsu.blocks.BaseObjBlock;
 import com.fangsu.client.ClientHooks;
+import com.fangsu.customItem.CustomItems;
 import com.fangsu.customItem.ModelSelectInfo;
 import com.fangsu.customItem.SubModelDispInfo;
 import com.fangsu.extraConfig.ConfigEntry;
@@ -39,6 +40,7 @@ import net.minecraft.world.phys.shapes.VoxelShape;
 import org.jetbrains.annotations.NotNull;
 
 import java.util.HashMap;
+import java.util.ArrayList;
 import java.util.List;
 import java.util.Map;
 
@@ -401,6 +403,34 @@ public abstract class BaseObjBlockEntity extends BlockEntity implements Syncable
 
     public List<SubModelDispInfo> getSubModelInfos() {
         return null;
+    }
+
+    protected SubModelDispInfo createSubModelSelectInfo(String nestedKeyPath, String defaultSubModel) {
+        return createSubModelSelectInfo(nestedKeyPath, "subModel", defaultSubModel);
+    }
+
+    protected SubModelDispInfo createSubModelSelectInfo(String nestedKeyPath, String subModelKey, String defaultSubModel) {
+        List<ModelSelectInfo> options = getModelSelectOptions(nestedKeyPath);
+        return new SubModelDispInfo(
+                Component.translatable("ui.fangsu.block.subModelSelect"),
+                options,
+                be -> this.subModels.getOrDefault(subModelKey, defaultSubModel),
+                (be, v) -> this.subModels.put(subModelKey, v)
+        );
+    }
+
+    protected List<ModelSelectInfo> getModelSelectOptions(String nestedKeyPath) {
+        return new ArrayList<>(CustomItems.getModelSelectInfos(this.mainModel, nestedKeyPath));
+    }
+
+    protected static Vec3 transformOffset(Direction facing, Vec3 trans) {
+        return switch (facing) {
+            case NORTH -> new Vec3(trans.x, trans.y, -trans.z);
+            case SOUTH -> new Vec3(-trans.x, trans.y, trans.z);
+            case WEST -> new Vec3(trans.z, trans.y, -trans.x);
+            case EAST -> new Vec3(-trans.z, trans.y, trans.x);
+            default -> trans;
+        };
     }
 
     protected void markShapeDirty() {

--- a/common/src/main/java/com/fangsu/blockEntities/BlockEntityDiaoban.java
+++ b/common/src/main/java/com/fangsu/blockEntities/BlockEntityDiaoban.java
@@ -93,7 +93,7 @@ public class BlockEntityDiaoban extends BaseObjBlockEntity implements IPlatformD
         reloadRoute();
 
         try {
-            DiaobanContent.DiaobanDisplayInfo displayInfo = DiaobanContent.loadDisplayInfo(mainModel, subModel);
+            DiaobanContent.DiaobanDisplayInfo displayInfo = ContentInfoUtil.getDiaobanDisplayInfo(mainModel, subModel);
             if (displayInfo == null) {
                 markedError = true;
                 return;
@@ -270,9 +270,7 @@ public class BlockEntityDiaoban extends BaseObjBlockEntity implements IPlatformD
     @Override
     public List<SubModelDispInfo> getSubModelInfos() {
         List<SubModelDispInfo> infos = new ArrayList<>();
-        List<ModelSelectInfo> thisInfo = new ArrayList<>();
         List<ModelSelectInfo> drawFuncs = new ArrayList<>();
-        thisInfo.addAll(DiaobanContent.loadModelSelectInfos(this.mainModel));
         try {
             JsonObject loaded = ResourceUtil.loadAsJSON(new ResourceLocation("fangsu:diaoban/diaoban_scripts.json")).getAsJsonObject();
             if (loaded.has("content")) {
@@ -292,11 +290,7 @@ public class BlockEntityDiaoban extends BaseObjBlockEntity implements IPlatformD
             }
         } catch (Exception ignored) {
         }
-        infos.add(new SubModelDispInfo(
-                Component.translatable("ui.fangsu.block.subModelSelect"),
-                thisInfo,
-                (be) -> this.subModels.getOrDefault("subModel", DEFAULT_SUB_MODEL),
-                (be, v) -> this.subModels.put("subModel", v)));
+        infos.add(createSubModelSelectInfo("content", DEFAULT_SUB_MODEL));
         infos.add(new SubModelDispInfo(
                 Component.translatable("ui.fangsu.diaoban.selectDrawFunction"),
                 drawFuncs,

--- a/common/src/main/java/com/fangsu/blockEntities/BlockEntityPids.java
+++ b/common/src/main/java/com/fangsu/blockEntities/BlockEntityPids.java
@@ -3,7 +3,6 @@ package com.fangsu.blockEntities;
 import com.fangsu.Main;
 import com.fangsu.blocks.BaseObjBlock;
 import com.fangsu.client.ClientHooks;
-import com.fangsu.customItem.ModelSelectInfo;
 import com.fangsu.customItem.SubModelDispInfo;
 import com.fangsu.customItem.SubModelMethodInfo;
 import com.fangsu.customItem.contents.PidsContent;
@@ -78,7 +77,7 @@ public class BlockEntityPids extends BaseObjBlockEntity {
         }
 
         try {
-            PidsContent.PidsDisplayInfo displayInfo = PidsContent.loadDisplayInfo(mainModel, subModel);
+            PidsContent.PidsDisplayInfo displayInfo = ContentInfoUtil.getPidsDisplayInfo(mainModel, subModel);
             if (displayInfo == null) {
                 markedError = true;
                 return;
@@ -326,13 +325,7 @@ public class BlockEntityPids extends BaseObjBlockEntity {
     @Override
     public List<SubModelDispInfo> getSubModelInfos() {
         List<SubModelDispInfo> infos = new ArrayList<>();
-        List<ModelSelectInfo> thisInfo = new ArrayList<>();
-        thisInfo.addAll(PidsContent.loadModelSelectInfos(this.mainModel));
-        infos.add(new SubModelDispInfo(
-                Component.translatable("ui.fangsu.block.subModelSelect"),
-                thisInfo,
-                (be) -> this.subModels.getOrDefault("subModel", DEFAULT_SUB_MODEL),
-                (be, v) -> this.subModels.put("subModel", v)));
+        infos.add(createSubModelSelectInfo("content", DEFAULT_SUB_MODEL));
         infos.add(new SubModelMethodInfo(
                 Component.translatable("ui.fangsu.common.selectPlat"),
                 () -> {
@@ -349,16 +342,6 @@ public class BlockEntityPids extends BaseObjBlockEntity {
                 }
         ));
         return infos;
-    }
-
-    private static Vec3 transformOffset(Direction facing, Vec3 trans) {
-        return switch (facing) {
-            case NORTH -> new Vec3(trans.x, trans.y, -trans.z);
-            case SOUTH -> new Vec3(-trans.x, trans.y, trans.z);
-            case WEST -> new Vec3(trans.z, trans.y, -trans.x);
-            case EAST -> new Vec3(-trans.z, trans.y, trans.x);
-            default -> trans;
-        };
     }
 
     private List<MtrUtil.PidsArrivalInfo> getArrivalInfoList() {

--- a/common/src/main/java/com/fangsu/blockEntities/BlockEntityScreendoor.java
+++ b/common/src/main/java/com/fangsu/blockEntities/BlockEntityScreendoor.java
@@ -9,6 +9,7 @@ import com.fangsu.extraConfig.*;
 import com.fangsu.render.scripting.util.DynamicModelHolder;
 import com.fangsu.render.sowcer.math.Matrices;
 import com.fangsu.utils.CollisionBoxUtil;
+import com.fangsu.utils.ContentInfoUtil;
 import com.fangsu.utils.CustomItemHelper;
 import com.fangsu.utils.FacingBlockUtil;
 import com.fangsu.utils.ResourceUtil;
@@ -164,7 +165,7 @@ public class BlockEntityScreendoor extends BaseObjBlockEntity implements Syncabl
                             dispDoorSide == 1 ? CustomItemHelper.checkSubModel(this, "subModel", DEFAULT_SUB_MODEL_RIGHT) :
                                     CustomItemHelper.checkSubModel(this, "subModel", DEFAULT_SUB_MODEL_FLEX);
 
-            ScreendoorDoorContent.ScreendoorDoorDisplayInfo displayInfo = ScreendoorDoorContent.loadDisplayInfo(mainModel, subModel, dispDoorSide);
+            ScreendoorDoorContent.ScreendoorDoorDisplayInfo displayInfo = ContentInfoUtil.getScreendoorDisplayInfo(mainModel, subModel, dispDoorSide);
             if (displayInfo == null) return;
 
             JsonObject mainJson = ResourceUtil.loadAsJSON(new ResourceLocation(mainModel)).getAsJsonObject();
@@ -232,7 +233,7 @@ public class BlockEntityScreendoor extends BaseObjBlockEntity implements Syncabl
     public List<SubModelDispInfo> getSubModelInfos() {
         List<SubModelDispInfo> infos = new ArrayList<>();
         List<ModelSelectInfo> thisInfo = new ArrayList<>();
-        thisInfo.addAll(ScreendoorDoorContent.loadModelSelectInfos(this.mainModel, dispDoorSide));
+        thisInfo.addAll(getModelSelectOptions(ContentInfoUtil.getScreendoorContentPath(dispDoorSide)));
         infos.add(new SubModelDispInfo(Component.translatable("ui.fangsu.block.subModelSelect"), thisInfo,
                 (be) -> this.subModels.getOrDefault("subModel",
                         dispDoorValue == 0 ? DEFAULT_SUB_MODEL_LEFT :
@@ -298,13 +299,4 @@ public class BlockEntityScreendoor extends BaseObjBlockEntity implements Syncabl
         }
     }
 
-    private static Vec3 transformOffset(Direction facing, Vec3 trans) {
-        return switch (facing) {
-            case NORTH -> new Vec3(trans.x, trans.y, -trans.z);
-            case SOUTH -> new Vec3(-trans.x, trans.y, trans.z);
-            case WEST -> new Vec3(trans.z, trans.y, -trans.x);
-            case EAST -> new Vec3(-trans.z, trans.y, trans.x);
-            default -> trans;
-        };
-    }
 }

--- a/common/src/main/java/com/fangsu/blockEntities/BlockEntityScreendoorGlass.java
+++ b/common/src/main/java/com/fangsu/blockEntities/BlockEntityScreendoorGlass.java
@@ -351,13 +351,4 @@ public class BlockEntityScreendoorGlass extends BaseObjBlockEntity implements Sy
         }
     }
 
-    private static Vec3 transformOffset(Direction facing, Vec3 trans) {
-        return switch (facing) {
-            case NORTH -> new Vec3(trans.x, trans.y, -trans.z);
-            case SOUTH -> new Vec3(-trans.x, trans.y, trans.z);
-            case WEST -> new Vec3(trans.z, trans.y, -trans.x);
-            case EAST -> new Vec3(-trans.z, trans.y, trans.x);
-            default -> trans;
-        };
-    }
 }

--- a/common/src/main/java/com/fangsu/blockEntities/BlockEntitySign.java
+++ b/common/src/main/java/com/fangsu/blockEntities/BlockEntitySign.java
@@ -2,7 +2,6 @@ package com.fangsu.blockEntities;
 
 import com.fangsu.Main;
 import com.fangsu.client.ClientHooks;
-import com.fangsu.customItem.ModelSelectInfo;
 import com.fangsu.customItem.SubModelDispInfo;
 import com.fangsu.customItem.SubModelMethodInfo;
 import com.fangsu.customItem.contents.SignContent;
@@ -18,6 +17,7 @@ import com.fangsu.drawing.sign.SignDrawContext;
 import com.fangsu.drawing.sign.SignItem;
 import com.fangsu.drawing.sign.SignItemFactory;
 import com.fangsu.utils.CollisionBoxUtil;
+import com.fangsu.utils.ContentInfoUtil;
 import com.fangsu.utils.CustomItemHelper;
 import com.fangsu.utils.ResourceUtil;
 import com.google.gson.*;
@@ -90,7 +90,7 @@ public class BlockEntitySign extends BaseObjBlockEntity implements Syncable {
         subModel = CustomItemHelper.checkSubModel(this, "subModel", DEFAULT_SUB_MODEL);
 
         try {
-            SignContent.SignDisplayInfo displayInfo = SignContent.loadDisplayInfo(mainModel, subModel);
+            SignContent.SignDisplayInfo displayInfo = ContentInfoUtil.getSignDisplayInfo(mainModel, subModel);
             if (displayInfo == null) {
                 markedError = true;
                 return;
@@ -336,13 +336,7 @@ public class BlockEntitySign extends BaseObjBlockEntity implements Syncable {
     @Override
     public List<SubModelDispInfo> getSubModelInfos() {
         List<SubModelDispInfo> infos = new ArrayList<>();
-        List<ModelSelectInfo> thisInfo = new ArrayList<>();
-        thisInfo.addAll(SignContent.loadModelSelectInfos(this.mainModel));
-        infos.add(new SubModelDispInfo(
-                Component.translatable("ui.fangsu.block.subModelSelect"),
-                thisInfo,
-                (be) -> this.subModels.getOrDefault("subModel", DEFAULT_SUB_MODEL),
-                (be, v) -> this.subModels.put("subModel", v)));
+        infos.add(createSubModelSelectInfo("common", DEFAULT_SUB_MODEL));
         infos.add(new SubModelMethodInfo(Component.translatable("ui.fangsu.sign.editSign"), () -> {
             if (itemsFront == null) itemsFront = new HashMap<>();
             if (itemsBack == null) itemsBack = new HashMap<>();

--- a/common/src/main/java/com/fangsu/blockEntities/BlockEntitySignOnWall.java
+++ b/common/src/main/java/com/fangsu/blockEntities/BlockEntitySignOnWall.java
@@ -2,7 +2,6 @@ package com.fangsu.blockEntities;
 
 import com.fangsu.Main;
 import com.fangsu.client.ClientHooks;
-import com.fangsu.customItem.ModelSelectInfo;
 import com.fangsu.customItem.SubModelDispInfo;
 import com.fangsu.customItem.SubModelMethodInfo;
 import com.fangsu.customItem.contents.SignOnWallContent;
@@ -19,6 +18,7 @@ import com.fangsu.drawing.sign.SignDrawContext;
 import com.fangsu.drawing.sign.SignItem;
 import com.fangsu.drawing.sign.SignItemFactory;
 import com.fangsu.utils.CollisionBoxUtil;
+import com.fangsu.utils.ContentInfoUtil;
 import com.fangsu.utils.CustomItemHelper;
 import com.fangsu.utils.ResourceUtil;
 import com.google.gson.*;
@@ -81,7 +81,7 @@ public class BlockEntitySignOnWall extends BaseObjBlockEntity implements Syncabl
         subModel = CustomItemHelper.checkSubModel(this, "subModel", DEFAULT_SUB_MODEL);
 
         try {
-            SignOnWallContent.SignOnWallDisplayInfo displayInfo = SignOnWallContent.loadDisplayInfo(mainModel, subModel);
+            SignOnWallContent.SignOnWallDisplayInfo displayInfo = ContentInfoUtil.getSignOnWallDisplayInfo(mainModel, subModel);
             if (displayInfo == null) {
                 markedError = true;
                 return;
@@ -227,13 +227,7 @@ public class BlockEntitySignOnWall extends BaseObjBlockEntity implements Syncabl
     @Override
     public List<SubModelDispInfo> getSubModelInfos() {
         List<SubModelDispInfo> infos = new ArrayList<>();
-        List<ModelSelectInfo> thisInfo = new ArrayList<>();
-        thisInfo.addAll(SignOnWallContent.loadModelSelectInfos(this.mainModel));
-        infos.add(new SubModelDispInfo(
-                Component.translatable("ui.fangsu.block.subModelSelect"),
-                thisInfo,
-                (be) -> this.subModels.getOrDefault("subModel", DEFAULT_SUB_MODEL),
-                (be, v) -> this.subModels.put("subModel", v)));
+        infos.add(createSubModelSelectInfo("on_wall", DEFAULT_SUB_MODEL));
         infos.add(new SubModelMethodInfo(Component.translatable("ui.fangsu.sign.editSign"), () -> {
             if (items == null) items = new HashMap<>();
             ClientHooks.openSignConfigScreen(1, List.of(items), saveItems -> {

--- a/common/src/main/java/com/fangsu/blockEntities/BlockEntityTicketBarrier.java
+++ b/common/src/main/java/com/fangsu/blockEntities/BlockEntityTicketBarrier.java
@@ -3,10 +3,10 @@ package com.fangsu.blockEntities;
 import com.fangsu.render.scripting.util.DynamicModelHolder;
 import com.fangsu.render.sowcer.math.Matrices;
 
-import com.fangsu.customItem.ModelSelectInfo;
 import com.fangsu.customItem.SubModelDispInfo;
 import com.fangsu.customItem.contents.TicketBarrierContent;
 import com.fangsu.Main;
+import com.fangsu.utils.ContentInfoUtil;
 import com.fangsu.utils.CustomItemHelper;
 import com.fangsu.utils.ResourceUtil;
 import com.fangsu.blocks.BaseObjBlock;
@@ -80,7 +80,7 @@ public class BlockEntityTicketBarrier extends BaseObjBlockEntity {
         String subModel = CustomItemHelper.checkSubModel(this, "subModel", DEFAULT_SUB_MODEL);
 
         try {
-            TicketBarrierContent.TicketBarrierDisplayInfo displayInfo = TicketBarrierContent.loadDisplayInfo(mainModel, subModel);
+            TicketBarrierContent.TicketBarrierDisplayInfo displayInfo = ContentInfoUtil.getTicketBarrierDisplayInfo(mainModel, subModel);
             if (displayInfo == null) {
                 markedError = true;
                 return;
@@ -294,11 +294,7 @@ public class BlockEntityTicketBarrier extends BaseObjBlockEntity {
     @Override
     public List<SubModelDispInfo> getSubModelInfos() {
         List<SubModelDispInfo> infos = new ArrayList<>();
-        List<ModelSelectInfo> thisInfo = new ArrayList<>();
-        thisInfo.addAll(TicketBarrierContent.loadModelSelectInfos(this.mainModel));
-        infos.add(new SubModelDispInfo(Component.translatable("ui.fangsu.block.subModelSelect"), thisInfo,
-                (be) -> this.subModels.getOrDefault("subModel", DEFAULT_SUB_MODEL),
-                (be, v) -> this.subModels.put("subModel", v)));
+        infos.add(createSubModelSelectInfo("", DEFAULT_SUB_MODEL));
         return infos;
     }
 
@@ -370,16 +366,6 @@ public class BlockEntityTicketBarrier extends BaseObjBlockEntity {
         VoxelShape closeShape = CollisionBoxUtil.cachedRotatedShape(posLong, closeCollision, Vec3.ZERO, rotX, rotY, rotZ, 0.1f);
         closeShape = closeShape.move(trans.x, trans.y, trans.z);
         return Shapes.or(openShape, closeShape);
-    }
-
-    private static Vec3 transformOffset(Direction facing, Vec3 trans) {
-        return switch (facing) {
-            case NORTH -> new Vec3(trans.x, trans.y, -trans.z);
-            case SOUTH -> new Vec3(-trans.x, trans.y, trans.z);
-            case WEST -> new Vec3(trans.z, trans.y, -trans.x);
-            case EAST -> new Vec3(-trans.z, trans.y, trans.x);
-            default -> trans;
-        };
     }
 
     private static AABB parseBox(List<?> rawList) {

--- a/common/src/main/java/com/fangsu/customItem/CustomItems.java
+++ b/common/src/main/java/com/fangsu/customItem/CustomItems.java
@@ -3,6 +3,8 @@ package com.fangsu.customItem;
 import com.fangsu.Main;
 import com.fangsu.customItem.contents.BaseContent;
 import com.fangsu.customItem.contents.ContentManager;
+import com.fangsu.customItem.contents.ContentResourceLoader;
+import com.fangsu.utils.ContentInfoUtil;
 import com.fangsu.utils.ResourceUtil;
 import com.google.gson.JsonArray;
 import com.google.gson.JsonElement;
@@ -31,6 +33,7 @@ public class CustomItems {
 
     public void reset() {
         items.clear();
+        ContentResourceLoader.reset();
         ContentManager cm = ContentManager.getInstance();
         cm.reset();
     }
@@ -55,6 +58,7 @@ public class CustomItems {
             long contentBegin = System.currentTimeMillis();
             List<ModelSelectInfo> thisItemInfo = getModelSelectInfos(value);
             items.put(key, thisItemInfo);
+            ContentInfoUtil.preloadByType(key, thisItemInfo);
             Main.LOGGER.debug("Loaded content {} in {} ms", key, System.currentTimeMillis() - contentBegin);
         }
         Main.LOGGER.info("Loaded {} items in {} ms", items.size(), System.currentTimeMillis() - begin);
@@ -77,6 +81,16 @@ public class CustomItems {
         }
         return thisItemInfo;
     }
+
+    public static Map<String, Object> getContentInfo(String mainModel, String nestedKeyPath, String subModel) {
+        Map<String, Map<String, Object>> loaded = ContentResourceLoader.loadMapByPath(new ResourceLocation(mainModel), nestedKeyPath);
+        if (loaded == null || !loaded.containsKey(subModel)) {
+            return null;
+        }
+        return loaded.get(subModel);
+    }
+
+    public static List<ModelSelectInfo> getModelSelectInfos(String mainModel, String nestedKeyPath) {
+        return ContentResourceLoader.loadModelSelectInfos(new ResourceLocation(mainModel), nestedKeyPath);
+    }
 }
-
-

--- a/common/src/main/java/com/fangsu/customItem/contents/ContentResourceLoader.java
+++ b/common/src/main/java/com/fangsu/customItem/contents/ContentResourceLoader.java
@@ -16,6 +16,11 @@ public final class ContentResourceLoader {
     private ContentResourceLoader() {
     }
 
+    public static void reset() {
+        CACHE.clear();
+        ROOT_CACHE.clear();
+    }
+
     public static JsonObject loadRoot(ResourceLocation location) {
         return ROOT_CACHE.computeIfAbsent(location.toString(), k -> {
             JsonElement element = ResourceUtil.loadAsJSON(location);

--- a/common/src/main/java/com/fangsu/customItem/contents/DiaobanContent.java
+++ b/common/src/main/java/com/fangsu/customItem/contents/DiaobanContent.java
@@ -1,11 +1,9 @@
 package com.fangsu.customItem.contents;
 
 import com.fangsu.Main;
-import com.fangsu.customItem.ModelSelectInfo;
 import com.google.gson.JsonArray;
 import com.google.gson.JsonElement;
 import com.google.gson.JsonObject;
-import net.minecraft.resources.ResourceLocation;
 
 import java.util.ArrayList;
 import java.util.HashMap;
@@ -28,33 +26,6 @@ public class DiaobanContent extends BaseContent {
 
     public boolean isFlipV() {
         return flipV;
-    }
-
-    public static DiaobanDisplayInfo loadDisplayInfo(String mainModel, String subModel) throws Exception {
-        Map<String, Map<String, Object>> loaded = ContentResourceLoader.loadMapByPath(new ResourceLocation(mainModel), "content");
-        if (loaded == null || !loaded.containsKey(subModel)) {
-            return null;
-        }
-        return DiaobanDisplayInfo.fromMap(loaded.get(subModel));
-    }
-
-    public static List<ModelSelectInfo> loadModelSelectInfos(String mainModel) {
-        List<ModelSelectInfo> infos = new ArrayList<>();
-        try {
-            Map<String, Map<String, Object>> loaded = ContentResourceLoader.loadMapByPath(new ResourceLocation(mainModel), "content");
-            if (loaded == null) {
-                return infos;
-            }
-            for (Map<String, Object> item : loaded.values()) {
-                String text = item.get("text") instanceof String s ? s : "";
-                String content = item.get("id") instanceof String s ? s : "";
-                String contentText = item.get("contentText") instanceof String s ? s : null;
-                if (contentText != null) infos.add(new ModelSelectInfo(text, content, contentText));
-                else infos.add(new ModelSelectInfo(text, content));
-            }
-        } catch (Exception ignored) {
-        }
-        return infos;
     }
 
     public static class DiaobanDisplayInfo {

--- a/common/src/main/java/com/fangsu/customItem/contents/PidsContent.java
+++ b/common/src/main/java/com/fangsu/customItem/contents/PidsContent.java
@@ -1,11 +1,9 @@
 package com.fangsu.customItem.contents;
 
 import com.fangsu.Main;
-import com.fangsu.customItem.ModelSelectInfo;
 import com.google.gson.JsonArray;
 import com.google.gson.JsonElement;
 import com.google.gson.JsonObject;
-import net.minecraft.resources.ResourceLocation;
 
 import java.util.ArrayList;
 import java.util.List;
@@ -27,33 +25,6 @@ public class PidsContent extends BaseContent {
 
     public boolean isFlipV() {
         return flipV;
-    }
-
-    public static PidsDisplayInfo loadDisplayInfo(String mainModel, String subModel) throws Exception {
-        Map<String, Map<String, Object>> loaded = ContentResourceLoader.loadMapByPath(new ResourceLocation(mainModel), "content");
-        if (loaded == null || !loaded.containsKey(subModel)) {
-            return null;
-        }
-        return PidsDisplayInfo.fromMap(loaded.get(subModel));
-    }
-
-    public static List<ModelSelectInfo> loadModelSelectInfos(String mainModel) {
-        List<ModelSelectInfo> infos = new ArrayList<>();
-        try {
-            Map<String, Map<String, Object>> loaded = ContentResourceLoader.loadMapByPath(new ResourceLocation(mainModel), "content");
-            if (loaded == null) {
-                return infos;
-            }
-            for (Map<String, Object> item : loaded.values()) {
-                String text = item.get("text") instanceof String s ? s : "";
-                String content = item.get("id") instanceof String s ? s : "";
-                String contentText = item.get("contentText") instanceof String s ? s : null;
-                if (contentText != null) infos.add(new ModelSelectInfo(text, content, contentText));
-                else infos.add(new ModelSelectInfo(text, content));
-            }
-        } catch (Exception ignored) {
-        }
-        return infos;
     }
 
     public static class PidsDisplayInfo {

--- a/common/src/main/java/com/fangsu/customItem/contents/ScreendoorDoorContent.java
+++ b/common/src/main/java/com/fangsu/customItem/contents/ScreendoorDoorContent.java
@@ -1,42 +1,9 @@
 package com.fangsu.customItem.contents;
 
-import com.fangsu.customItem.ModelSelectInfo;
-import net.minecraft.resources.ResourceLocation;
-
 import java.util.*;
 
 public final class ScreendoorDoorContent {
     private ScreendoorDoorContent() {
-    }
-
-    public static ScreendoorDoorDisplayInfo loadDisplayInfo(String mainModel, String subModel, int doorSide) {
-        String path = switch (doorSide) {
-            case 0 -> "door.left";
-            case 1 -> "door.right";
-            default -> "door.flex";
-        };
-        Map<String, Map<String, Object>> loaded = ContentResourceLoader.loadMapByPath(new ResourceLocation(mainModel), path);
-        if (loaded == null || !loaded.containsKey(subModel)) return null;
-        Map<String, Object> current = loaded.get(subModel);
-        List<DoorInfo> doors = new ArrayList<>();
-        if (current.get("doors") instanceof List<?> list) {
-            for (Object o : list) {
-                if (o instanceof Map<?, ?> m) {
-                    DoorInfo info = DoorInfo.fromMap(m);
-                    if (info != null) doors.add(info);
-                }
-            }
-        }
-        return new ScreendoorDoorDisplayInfo(doors);
-    }
-
-    public static List<ModelSelectInfo> loadModelSelectInfos(String mainModel, int doorSide) {
-        String path = switch (doorSide) {
-            case 0 -> "door.left";
-            case 1 -> "door.right";
-            default -> "door.flex";
-        };
-        return ContentResourceLoader.loadModelSelectInfos(new ResourceLocation(mainModel), path);
     }
 
     public record ScreendoorDoorDisplayInfo(List<DoorInfo> doors) {

--- a/common/src/main/java/com/fangsu/customItem/contents/SignContent.java
+++ b/common/src/main/java/com/fangsu/customItem/contents/SignContent.java
@@ -1,23 +1,10 @@
 package com.fangsu.customItem.contents;
 
-import com.fangsu.customItem.ModelSelectInfo;
-import net.minecraft.resources.ResourceLocation;
-
 import java.util.List;
 import java.util.Map;
 
 public final class SignContent {
     private SignContent() {
-    }
-
-    public static SignDisplayInfo loadDisplayInfo(String mainModel, String subModel) {
-        Map<String, Map<String, Object>> loaded = ContentResourceLoader.loadMapByPath(new ResourceLocation(mainModel), "common");
-        if (loaded == null || !loaded.containsKey(subModel)) return null;
-        return SignDisplayInfo.fromMap(loaded.get(subModel));
-    }
-
-    public static List<ModelSelectInfo> loadModelSelectInfos(String mainModel) {
-        return ContentResourceLoader.loadModelSelectInfos(new ResourceLocation(mainModel), "common");
     }
 
     public record SignDisplayInfo(

--- a/common/src/main/java/com/fangsu/customItem/contents/SignOnWallContent.java
+++ b/common/src/main/java/com/fangsu/customItem/contents/SignOnWallContent.java
@@ -1,23 +1,10 @@
 package com.fangsu.customItem.contents;
 
-import com.fangsu.customItem.ModelSelectInfo;
-import net.minecraft.resources.ResourceLocation;
-
 import java.util.List;
 import java.util.Map;
 
 public final class SignOnWallContent {
     private SignOnWallContent() {
-    }
-
-    public static SignOnWallDisplayInfo loadDisplayInfo(String mainModel, String subModel) {
-        Map<String, Map<String, Object>> loaded = ContentResourceLoader.loadMapByPath(new ResourceLocation(mainModel), "on_wall");
-        if (loaded == null || !loaded.containsKey(subModel)) return null;
-        return SignOnWallDisplayInfo.fromMap(loaded.get(subModel));
-    }
-
-    public static List<ModelSelectInfo> loadModelSelectInfos(String mainModel) {
-        return ContentResourceLoader.loadModelSelectInfos(new ResourceLocation(mainModel), "on_wall");
     }
 
     public record SignOnWallDisplayInfo(

--- a/common/src/main/java/com/fangsu/customItem/contents/TicketBarrierContent.java
+++ b/common/src/main/java/com/fangsu/customItem/contents/TicketBarrierContent.java
@@ -1,11 +1,9 @@
 package com.fangsu.customItem.contents;
 
 import com.fangsu.Main;
-import com.fangsu.customItem.ModelSelectInfo;
 import com.google.gson.JsonArray;
 import com.google.gson.JsonElement;
 import com.google.gson.JsonObject;
-import net.minecraft.resources.ResourceLocation;
 
 import java.util.ArrayList;
 import java.util.HashMap;
@@ -29,33 +27,6 @@ public class TicketBarrierContent extends BaseContent {
 
     public boolean getFilpV() {
         return filpV;
-    }
-
-    public static TicketBarrierDisplayInfo loadDisplayInfo(String mainModel, String subModel) throws Exception {
-        Map<String, Map<String, Object>> loaded = ContentResourceLoader.loadMapByPath(new ResourceLocation(mainModel));
-        if (loaded == null || !loaded.containsKey(subModel)) {
-            return null;
-        }
-        return TicketBarrierDisplayInfo.fromMap(loaded.get(subModel));
-    }
-
-    public static List<ModelSelectInfo> loadModelSelectInfos(String mainModel) {
-        List<ModelSelectInfo> infos = new ArrayList<>();
-        try {
-            Map<String, Map<String, Object>> loaded = ContentResourceLoader.loadMapByPath(new ResourceLocation(mainModel));
-            if (loaded == null) {
-                return infos;
-            }
-            for (Map<String, Object> item : loaded.values()) {
-                String text = item.get("text") instanceof String s ? s : "";
-                String content = item.get("id") instanceof String s ? s : "";
-                String contentText = item.get("contentText") instanceof String s ? s : null;
-                if (contentText != null) infos.add(new ModelSelectInfo(text, content, contentText));
-                else infos.add(new ModelSelectInfo(text, content));
-            }
-        } catch (Exception ignored) {
-        }
-        return infos;
     }
 
     public static class TicketBarrierDisplayInfo {

--- a/common/src/main/java/com/fangsu/utils/ContentInfoUtil.java
+++ b/common/src/main/java/com/fangsu/utils/ContentInfoUtil.java
@@ -1,0 +1,85 @@
+package com.fangsu.utils;
+
+import com.fangsu.customItem.CustomItems;
+import com.fangsu.customItem.ModelSelectInfo;
+import com.fangsu.customItem.contents.*;
+import net.minecraft.resources.ResourceLocation;
+
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Map;
+
+public final class ContentInfoUtil {
+    private ContentInfoUtil() {
+    }
+
+    public static PidsContent.PidsDisplayInfo getPidsDisplayInfo(String mainModel, String subModel) {
+        return PidsContent.PidsDisplayInfo.fromMap(CustomItems.getContentInfo(mainModel, "content", subModel));
+    }
+
+    public static DiaobanContent.DiaobanDisplayInfo getDiaobanDisplayInfo(String mainModel, String subModel) {
+        return DiaobanContent.DiaobanDisplayInfo.fromMap(CustomItems.getContentInfo(mainModel, "content", subModel));
+    }
+
+    public static TicketBarrierContent.TicketBarrierDisplayInfo getTicketBarrierDisplayInfo(String mainModel, String subModel) {
+        return TicketBarrierContent.TicketBarrierDisplayInfo.fromMap(CustomItems.getContentInfo(mainModel, "", subModel));
+    }
+
+    public static SignContent.SignDisplayInfo getSignDisplayInfo(String mainModel, String subModel) {
+        return SignContent.SignDisplayInfo.fromMap(CustomItems.getContentInfo(mainModel, "common", subModel));
+    }
+
+    public static SignOnWallContent.SignOnWallDisplayInfo getSignOnWallDisplayInfo(String mainModel, String subModel) {
+        return SignOnWallContent.SignOnWallDisplayInfo.fromMap(CustomItems.getContentInfo(mainModel, "on_wall", subModel));
+    }
+
+    public static ScreendoorDoorContent.ScreendoorDoorDisplayInfo getScreendoorDisplayInfo(String mainModel, String subModel, int doorSide) {
+        Map<String, Object> current = CustomItems.getContentInfo(mainModel, getScreendoorContentPath(doorSide), subModel);
+        if (current == null) return null;
+        List<ScreendoorDoorContent.DoorInfo> doors = new ArrayList<>();
+        if (current.get("doors") instanceof List<?> list) {
+            for (Object o : list) {
+                if (o instanceof Map<?, ?> m) {
+                    ScreendoorDoorContent.DoorInfo info = ScreendoorDoorContent.DoorInfo.fromMap(m);
+                    if (info != null) doors.add(info);
+                }
+            }
+        }
+        return new ScreendoorDoorContent.ScreendoorDoorDisplayInfo(doors);
+    }
+
+    public static String getScreendoorContentPath(int doorSide) {
+        return switch (doorSide) {
+            case 0 -> "door.left";
+            case 1 -> "door.right";
+            default -> "door.flex";
+        };
+    }
+
+    public static void preloadByType(String contentType, List<ModelSelectInfo> infos) {
+        if (infos == null || infos.isEmpty()) return;
+        for (ModelSelectInfo info : infos) {
+            preloadByType(contentType, info.content());
+        }
+    }
+
+    public static void preloadByType(String contentType, String modelPath) {
+        ResourceLocation location = new ResourceLocation(modelPath);
+        switch (contentType) {
+            case "ticketBarrier" -> ContentResourceLoader.loadMapByPath(location, "");
+            case "pids", "diaoban" -> ContentResourceLoader.loadMapByPath(location, "content");
+            case "screendoor" -> {
+                ContentResourceLoader.loadMapByPath(location, "door.left");
+                ContentResourceLoader.loadMapByPath(location, "door.right");
+                ContentResourceLoader.loadMapByPath(location, "door.flex");
+                ContentResourceLoader.loadMapByPath(location, "glass.left");
+                ContentResourceLoader.loadMapByPath(location, "glass.right");
+            }
+            case "sign" -> {
+                ContentResourceLoader.loadMapByPath(location, "common");
+                ContentResourceLoader.loadMapByPath(location, "on_wall");
+            }
+            default -> ContentResourceLoader.loadRoot(location);
+        }
+    }
+}


### PR DESCRIPTION
### Motivation
- Consolidate duplicate content parsing/loading logic across multiple custom content types into a single utility to simplify maintenance and support preloading.
- Provide a reusable UI helper for sub-model selection and centralize `transformOffset` to avoid repeated implementations across block entities.
- Improve caching/reset behavior for content resources to allow safe reloads.
- Reduce boilerplate in content classes and block entities by delegating display/info lookup to the new utility layer.

### Description
- Added `ContentInfoUtil` which exposes typed getters like `getPidsDisplayInfo`, `getDiaobanDisplayInfo`, `getSignDisplayInfo`, `getScreendoorDisplayInfo`, and `preloadByType` to centralize mapping from main model files to typed display info.
- Implemented `ContentResourceLoader.reset()` and extended the loader to cache and expose content maps; added `ContentResourceLoader` usage in `CustomItems` for preloading content resources during initialization.
- Extended `CustomItems` with `getContentInfo` and `getModelSelectInfos` helpers and updated `CustomItems.init()` to call `ContentInfoUtil.preloadByType` after loading model selection lists.
- Added helpers to `BaseObjBlockEntity`: `createSubModelSelectInfo`, `getModelSelectOptions` and a single `transformOffset` implementation, and removed duplicate `transformOffset` implementations from multiple block entities.
- Updated multiple block entity classes (`BlockEntityDiaoban`, `BlockEntityPids`, `BlockEntityScreendoor`, `BlockEntitySign`, `BlockEntitySignOnWall`, `BlockEntityTicketBarrier`, `BlockEntityScreendoorGlass`, etc.) to use `ContentInfoUtil` for display info and to use the new `createSubModelSelectInfo`/`getModelSelectOptions` helpers for model selection UI.
- Removed or simplified per-content `loadDisplayInfo` and `loadModelSelectInfos` methods from individual content classes in favor of the centralized approach.

### Testing
- Performed a project compile with `./gradlew build` to verify the code changes integrate and the project compiles successfully.
- No additional automated unit tests were added or modified as part of this change.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69dce79a8560832e9da90eecbac21c30)