### PR TITLE
Serialize shapes and use ShapeSerializer for dynamic VoxelShape computation (Diaoban, TicketBarrier, ScreendoorGlass)

### DIFF
--- a/common/src/main/java/com/fangsu/blockEntities/BlockEntityDiaoban.java
+++ b/common/src/main/java/com/fangsu/blockEntities/BlockEntityDiaoban.java
@@ -9,6 +9,7 @@ import com.fangsu.customItem.contents.DiaobanContent;
 import com.fangsu.extraConfig.*;
 import com.fangsu.mtr.LocalRoute;
 import com.fangsu.mtr.LocalRouteDetail;
+import com.fangsu.blocks.BaseObjBlock;
 import com.fangsu.render.scripting.util.DynamicModelHolder;
 import com.fangsu.render.sowcer.math.Matrices;
 import com.fangsu.render.sowcerext.model.RawModel;
@@ -26,14 +27,19 @@ import com.google.gson.JsonObject;
 import com.google.gson.JsonPrimitive;
 import mtr.data.Platform;
 import net.minecraft.core.BlockPos;
+import net.minecraft.core.Direction;
 import net.minecraft.network.chat.Component;
 import net.minecraft.resources.ResourceLocation;
 import net.minecraft.world.InteractionHand;
 import net.minecraft.world.InteractionResult;
 import net.minecraft.world.entity.player.Player;
 import net.minecraft.world.level.Level;
+import net.minecraft.world.level.block.Block;
 import net.minecraft.world.level.block.state.BlockState;
 import net.minecraft.world.phys.BlockHitResult;
+import net.minecraft.world.phys.Vec3;
+import net.minecraft.world.phys.shapes.Shapes;
+import net.minecraft.world.phys.shapes.VoxelShape;
 
 import java.awt.*;
 import java.util.*;
@@ -52,7 +58,9 @@ public class BlockEntityDiaoban extends BaseObjBlockEntity implements IPlatformD
     protected String drawScript;
 
     private DynamicModelHolder dmhLeft, dmhCenter, dmhRight, dmhDlOn, dmhDlOff, dmhDisp = new DynamicModelHolder();
-    private CollisionBoxUtil.CollisionBox shape;
+    private String shapeLeftSerialized = "";
+    private String shapeCenterSerialized = "";
+    private String shapeRightSerialized = "";
     private Map<String, JsonElement> userExtraConfigs;
 
     private volatile ScriptHolderBase scriptHolder;
@@ -164,12 +172,68 @@ public class BlockEntityDiaoban extends BaseObjBlockEntity implements IPlatformD
             texW = texSize * length + 1;
             texH = texSize;
 
+            Map<String, List<Double>> shapeMap = displayInfo.getShape();
+            shapeLeftSerialized = ShapeSerializer.serialize(shapeMap.get("left"));
+            shapeCenterSerialized = ShapeSerializer.serialize(shapeMap.get("center"));
+            shapeRightSerialized = ShapeSerializer.serialize(shapeMap.get("right"));
+
 
             firstInit = true;
             scriptInit = false;
 
         } catch (Exception e) {
             Main.LOGGER.warn("Failed to load diaoban: {}", e.getMessage());
+        }
+    }
+
+    @Override
+    public VoxelShape setCollisionShape(BlockState state) {
+        return getDiaobanShape(state, true);
+    }
+
+    @Override
+    public VoxelShape setShape(BlockState state) {
+        return getDiaobanShape(state, false);
+    }
+
+    private VoxelShape getDiaobanShape(BlockState state, boolean collision) {
+        try {
+            String serialized = buildDiaobanShapeString();
+            if (serialized.isEmpty()) return collision ? Shapes.empty() : Shapes.block();
+            Direction facing = state.getValue(BaseObjBlock.FACING);
+            int yRot = Math.floorMod((int) facing.toYRot(), 360);
+            VoxelShape shape = ShapeSerializer.getShape(serialized, yRot);
+            Vec3 trans = transformOffset(facing, new Vec3(translateX, translateY, translateZ));
+            return shape.move(trans.x, trans.y, trans.z);
+        } catch (Exception e) {
+            return collision ? Shapes.empty() : Block.box(0, 0, 0, 16, 16, 16);
+        }
+    }
+
+    private String buildDiaobanShapeString() {
+        if (length <= 0) return "";
+        List<String> parts = new ArrayList<>();
+        double startX = (-0.5 * unit * (length - 1));
+        appendShapeWithOffset(parts, shapeLeftSerialized, startX);
+        for (int i = 0; i < length - 2; i++) {
+            appendShapeWithOffset(parts, shapeCenterSerialized, startX + (i + 1) * unit);
+        }
+        appendShapeWithOffset(parts, shapeRightSerialized, startX + (length - 1) * unit);
+        return String.join("/", parts);
+    }
+
+    private void appendShapeWithOffset(List<String> parts, String serialized, double offsetX) {
+        if (serialized == null || serialized.isEmpty()) return;
+        String[] boxes = serialized.split("/");
+        for (String box : boxes) {
+            String[] values = box.split(",");
+            if (values.length != 6) continue;
+            try {
+                double x1 = Double.parseDouble(values[0].trim()) + offsetX;
+                double x2 = Double.parseDouble(values[3].trim()) + offsetX;
+                parts.add(x1 + "," + values[1].trim() + "," + values[2].trim() + "," + x2 + "," + values[4].trim() + "," + values[5].trim());
+            } catch (Exception ignored) {
+            }
         }
     }
 

--- a/common/src/main/java/com/fangsu/blockEntities/BlockEntityScreendoorGlass.java
+++ b/common/src/main/java/com/fangsu/blockEntities/BlockEntityScreendoorGlass.java
@@ -94,68 +94,75 @@ public class BlockEntityScreendoorGlass extends BaseObjBlockEntity implements Sy
 
     // ★ 抽出的 auto 重算逻辑
     private void recomputeAuto() {
+        subModelLeft = subModels.getOrDefault("subModelLeft", DEFAULT_SUB_MODEL_LEFT);
+        subModelRight = subModels.getOrDefault("subModelRight", DEFAULT_SUB_MODEL_RIGHT);
+        actualSubModelLeft = subModelLeft;
+        actualSubModelRight = subModelRight;
+
         Map<String, Object> a = loadedLeft.get(subModelLeft);
         Map<String, Object> b = loadedRight.get(subModelRight);
         boolean leftIsAuto = a != null && a.containsKey("auto");
         boolean rightIsAuto = b != null && b.containsKey("auto");
 
-        if (!leftIsAuto && !rightIsAuto) return;
-
         String prevLeft = actualSubModelLeft;
         String prevRight = actualSubModelRight;
 
         try {
-            String autoKey = (String) loadedLeft.get(subModelLeft).get("auto");
-            List<JsonObject> commands = ScreendoorGlassContent.loadAutoCommands(mainModel, autoKey);
+            if (leftIsAuto || rightIsAuto) {
+                String autoKey = (String) loadedLeft.get(subModelLeft).get("auto");
+                List<JsonObject> commands = ScreendoorGlassContent.loadAutoCommands(mainModel, autoKey);
 
-            blockRelation.refresh();
+                blockRelation.refresh();
 
-            for (int i = commands.size() - 1; i >= 0; i--) {
-                JsonObject commandJson = commands.get(i);
-                if (!commandJson.has("if")) continue;
+                for (int i = commands.size() - 1; i >= 0; i--) {
+                    JsonObject commandJson = commands.get(i);
+                    if (!commandJson.has("if")) continue;
 
-                boolean isAvailable = false;
-                JsonElement ifElement = commandJson.get("if");
+                    boolean isAvailable = false;
+                    JsonElement ifElement = commandJson.get("if");
 
-                // if: "LEFT_BLOCK"
-                if (ifElement.isJsonPrimitive()) {
-                    String key = ifElement.getAsString();
-                    if ("TRUE".equals(key)) {
-                        isAvailable = true;
-                    } else {
-                        String target = blockRelation.get(key);
-                        if (commandJson.has("is")) {
-                            isAvailable = target.equals(commandJson.get("is").getAsString());
-                        } else if (commandJson.has("not")) {
-                            isAvailable = !target.equals(commandJson.get("not").getAsString());
+                    // if: "LEFT_BLOCK"
+                    if (ifElement.isJsonPrimitive()) {
+                        String key = ifElement.getAsString();
+                        if ("TRUE".equals(key)) {
+                            isAvailable = true;
+                        } else {
+                            String target = blockRelation.get(key);
+                            if (commandJson.has("is")) {
+                                isAvailable = target.equals(commandJson.get("is").getAsString());
+                            } else if (commandJson.has("not")) {
+                                isAvailable = !target.equals(commandJson.get("not").getAsString());
+                            }
                         }
                     }
-                }
-                // if: { ... }
-                else if (ifElement.isJsonObject()) {
-                    boolean failed = false;
-                    for (Map.Entry<String, JsonElement> e : ifElement.getAsJsonObject().entrySet()) {
-                        String target = blockRelation.get(e.getKey());
-                        JsonObject cond = e.getValue().getAsJsonObject();
-                        if (cond.has("is") && !target.equals(cond.get("is").getAsString())) {
-                            failed = true;
-                            break;
+                    // if: { ... }
+                    else if (ifElement.isJsonObject()) {
+                        boolean failed = false;
+                        for (Map.Entry<String, JsonElement> e : ifElement.getAsJsonObject().entrySet()) {
+                            String target = blockRelation.get(e.getKey());
+                            JsonObject cond = e.getValue().getAsJsonObject();
+                            if (cond.has("is") && !target.equals(cond.get("is").getAsString())) {
+                                failed = true;
+                                break;
+                            }
+                            if (cond.has("not") && target.equals(cond.get("not").getAsString())) {
+                                failed = true;
+                                break;
+                            }
                         }
-                        if (cond.has("not") && target.equals(cond.get("not").getAsString())) {
-                            failed = true;
-                            break;
-                        }
+                        isAvailable = !failed;
                     }
-                    isAvailable = !failed;
-                }
 
-                if (isAvailable) {
-                    if (leftIsAuto && commandJson.has("left"))
-                        actualSubModelLeft = commandJson.get("left").getAsString();
-                    if (rightIsAuto && commandJson.has("right"))
-                        actualSubModelRight = commandJson.get("right").getAsString();
+                    if (isAvailable) {
+                        if (leftIsAuto && commandJson.has("left"))
+                            actualSubModelLeft = commandJson.get("left").getAsString();
+                        if (rightIsAuto && commandJson.has("right"))
+                            actualSubModelRight = commandJson.get("right").getAsString();
+                    }
                 }
             }
+
+            reloadModelAndShape();
 
             // ★ 结果变了才通知邻居
             boolean changed =
@@ -164,7 +171,6 @@ public class BlockEntityScreendoorGlass extends BaseObjBlockEntity implements Sy
 
             if (changed) {
                 notifyNeighborsForAuto();
-                reloadModelAndShape();
             }
 
         } catch (Exception e) {
@@ -181,6 +187,7 @@ public class BlockEntityScreendoorGlass extends BaseObjBlockEntity implements Sy
 
         Map<String, Object> left = loadedLeft.get(actualSubModelLeft);
         Map<String, Object> right = loadedRight.get(actualSubModelRight);
+        if (left == null || right == null) return;
 
         dhmLeft = dhmRight = null;
         shapeLeft = shapeRight = null;
@@ -231,11 +238,34 @@ public class BlockEntityScreendoorGlass extends BaseObjBlockEntity implements Sy
 
     @Override
     public void whenSaving(Map<String, String> extraConfigs) {
+        if (DEFAULT_SUB_MODEL_LEFT.equals(subModels.getOrDefault("subModelLeft", DEFAULT_SUB_MODEL_LEFT))
+                && actualSubModelLeft != null && !actualSubModelLeft.isEmpty()) {
+            subModels.put("subModelLeft", actualSubModelLeft);
+        }
+        if (DEFAULT_SUB_MODEL_RIGHT.equals(subModels.getOrDefault("subModelRight", DEFAULT_SUB_MODEL_RIGHT))
+                && actualSubModelRight != null && !actualSubModelRight.isEmpty()) {
+            subModels.put("subModelRight", actualSubModelRight);
+        }
     }
 
     @Override
     public InteractionResult whenUseWithOther(Level level, BlockPos pos, Player player, InteractionHand hand, BlockHitResult hit) {
         return InteractionResult.PASS;
+    }
+
+    @Override
+    public InteractionResult whenUseWithBrush(Level level, BlockPos pos, Player player, InteractionHand hand, BlockHitResult hit) {
+        if (level.isClientSide) return InteractionResult.SUCCESS;
+        triggerAutoSync(true, true);
+        BlockEntity left = FacingBlockUtil.getLeftBlockEntity(level, pos, getBlockState());
+        if (left instanceof BlockEntityScreendoorGlass g) {
+            g.triggerAutoSync(false, true);
+        }
+        BlockEntity right = FacingBlockUtil.getRightBlockEntity(level, pos, getBlockState());
+        if (right instanceof BlockEntityScreendoorGlass g) {
+            g.triggerAutoSync(true, false);
+        }
+        return InteractionResult.SUCCESS;
     }
 
     @Override
@@ -289,6 +319,15 @@ public class BlockEntityScreendoorGlass extends BaseObjBlockEntity implements Sy
     @Override
     public void afterChangeModel() {
         recomputeAuto();
+    }
+
+    private void triggerAutoSync(boolean triggerLeft, boolean triggerRight) {
+        if (triggerLeft) subModels.put("subModelLeft", DEFAULT_SUB_MODEL_LEFT);
+        if (triggerRight) subModels.put("subModelRight", DEFAULT_SUB_MODEL_RIGHT);
+        pendingAuto = true;
+        recomputeAuto();
+        sendUpdateC2S();
+        setChanged();
     }
 
     // =========================================================

--- a/common/src/main/java/com/fangsu/blockEntities/BlockEntityTicketBarrier.java
+++ b/common/src/main/java/com/fangsu/blockEntities/BlockEntityTicketBarrier.java
@@ -9,6 +9,7 @@ import com.fangsu.Main;
 import com.fangsu.utils.ContentInfoUtil;
 import com.fangsu.utils.CustomItemHelper;
 import com.fangsu.utils.ResourceUtil;
+import com.fangsu.utils.ShapeSerializer;
 import com.fangsu.blocks.BaseObjBlock;
 import com.fangsu.utils.CollisionBoxUtil;
 import com.fangsu.ticketSystem.*;
@@ -56,6 +57,10 @@ public class BlockEntityTicketBarrier extends BaseObjBlockEntity {
     private DynamicModelHolder mainDmh;
     private TicketBarrierDoorRenderInfo subInfo;
     private CollisionBoxUtil.CollisionBox shape, collisionShape, doorCloseShape, doorCloseCollisionShape;
+    private String shapeSerialized = "";
+    private String collisionShapeSerialized = "";
+    private String doorCloseShapeSerialized = "";
+    private String doorCloseCollisionShapeSerialized = "";
     private AABB ticketBox, cardBox;
 
     public BlockEntityTicketBarrier(BlockPos blockPos, BlockState blockState) {
@@ -106,6 +111,10 @@ public class BlockEntityTicketBarrier extends BaseObjBlockEntity {
             } else {
                 doorCloseCollisionShape = new CollisionBoxUtil.CollisionBox(List.of(List.of(1, 0, 12, 15, 24, 15)));
             }
+            shapeSerialized = ShapeSerializer.serialize(displayInfo.getShape());
+            collisionShapeSerialized = ShapeSerializer.serialize(displayInfo.getCollisionShape());
+            doorCloseShapeSerialized = ShapeSerializer.serialize(displayInfo.getDoorCloseShape());
+            doorCloseCollisionShapeSerialized = ShapeSerializer.serialize(displayInfo.getDoorCloseCollisionShape());
 
             gatePos = displayInfo.getGatePos() != null ? displayInfo.getGatePos().floatValue() : 0.5f;
 
@@ -294,7 +303,7 @@ public class BlockEntityTicketBarrier extends BaseObjBlockEntity {
     @Override
     public List<SubModelDispInfo> getSubModelInfos() {
         List<SubModelDispInfo> infos = new ArrayList<>();
-        infos.add(createSubModelSelectInfo("", DEFAULT_SUB_MODEL));
+        infos.add(createSubModelSelectInfo("content", DEFAULT_SUB_MODEL));
         return infos;
     }
 
@@ -318,6 +327,9 @@ public class BlockEntityTicketBarrier extends BaseObjBlockEntity {
                     continue;
                 }
                 DynamicModelHolder dmh = dmhs.get(door.getSubModel());
+                if (dmh == null && dmhs.size() == 1) {
+                    dmh = dmhs.values().iterator().next();
+                }
                 if (dmh == null) {
                     continue;
                 }
@@ -331,6 +343,14 @@ public class BlockEntityTicketBarrier extends BaseObjBlockEntity {
     }
 
     private VoxelShape buildOutlineShape(BlockState state, boolean isOpen) {
+        if (!shapeSerialized.isEmpty()) {
+            VoxelShape openShape = resolveSerializedShape(shapeSerialized, state);
+            if (isOpen || doorCloseShapeSerialized.isEmpty()) {
+                return openShape;
+            }
+            VoxelShape closeShape = resolveSerializedShape(doorCloseShapeSerialized, state);
+            return Shapes.or(openShape, closeShape);
+        }
         if (shape == null) return null;
         Direction facing = state.getValue(BaseObjBlock.FACING);
         Vec3 trans = transformOffset(facing, new Vec3(translateX, translateY, translateZ));
@@ -349,6 +369,17 @@ public class BlockEntityTicketBarrier extends BaseObjBlockEntity {
     }
 
     private VoxelShape buildCollisionShape(BlockState state, boolean isOpen) {
+        if (!shapeSerialized.isEmpty() || !collisionShapeSerialized.isEmpty()) {
+            String baseShape = !collisionShapeSerialized.isEmpty() ? collisionShapeSerialized : shapeSerialized;
+            if (baseShape.isEmpty()) return null;
+            VoxelShape openShape = resolveSerializedShape(baseShape, state);
+            String closeShapeRaw = !doorCloseCollisionShapeSerialized.isEmpty() ? doorCloseCollisionShapeSerialized : doorCloseShapeSerialized;
+            if (isOpen || closeShapeRaw.isEmpty()) {
+                return openShape;
+            }
+            VoxelShape closeShape = resolveSerializedShape(closeShapeRaw, state);
+            return Shapes.or(openShape, closeShape);
+        }
         CollisionBoxUtil.CollisionBox baseCollision = collisionShape != null ? collisionShape : shape;
         if (baseCollision == null) return null;
         CollisionBoxUtil.CollisionBox closeCollision = doorCloseCollisionShape != null ? doorCloseCollisionShape : doorCloseShape;
@@ -366,6 +397,17 @@ public class BlockEntityTicketBarrier extends BaseObjBlockEntity {
         VoxelShape closeShape = CollisionBoxUtil.cachedRotatedShape(posLong, closeCollision, Vec3.ZERO, rotX, rotY, rotZ, 0.1f);
         closeShape = closeShape.move(trans.x, trans.y, trans.z);
         return Shapes.or(openShape, closeShape);
+    }
+
+    private VoxelShape resolveSerializedShape(String serialized, BlockState state) {
+        try {
+            Direction facing = state.getValue(BaseObjBlock.FACING);
+            int yRot = Math.floorMod((int) facing.toYRot(), 360);
+            Vec3 trans = transformOffset(facing, new Vec3(translateX, translateY, translateZ));
+            return ShapeSerializer.getShape(serialized, yRot).move(trans.x, trans.y, trans.z);
+        } catch (Exception e) {
+            return Shapes.empty();
+        }
     }
 
     private static AABB parseBox(List<?> rawList) {

--- a/common/src/main/java/com/fangsu/customItem/contents/DiaobanContent.java
+++ b/common/src/main/java/com/fangsu/customItem/contents/DiaobanContent.java
@@ -38,9 +38,11 @@ public class DiaobanContent extends BaseContent {
         private final List<List<Double>> tex;
         private final Map<String, String> subModel;
         private final Map<String, Object> doorlight;
+        private final Map<String, List<Double>> shape;
 
         private DiaobanDisplayInfo(String model, boolean flipV, int unit, double leftSpace, double rightSpace, int texSize,
-                                   List<List<Double>> tex, Map<String, String> subModel, Map<String, Object> doorlight) {
+                                   List<List<Double>> tex, Map<String, String> subModel, Map<String, Object> doorlight,
+                                   Map<String, List<Double>> shape) {
             this.model = model;
             this.flipV = flipV;
             this.unit = unit;
@@ -50,6 +52,7 @@ public class DiaobanContent extends BaseContent {
             this.tex = tex;
             this.subModel = subModel;
             this.doorlight = doorlight;
+            this.shape = shape;
         }
 
         public static DiaobanDisplayInfo fromMap(Map<String, Object> current) {
@@ -87,7 +90,19 @@ public class DiaobanContent extends BaseContent {
                 if (m.get("type") instanceof String s) doorlight.put("type", s);
             }
 
-            return new DiaobanDisplayInfo(model, flipV, unit, leftSpace, rightSpace, texSize, tex, subModel, doorlight);
+            Map<String, List<Double>> shape = new HashMap<>();
+            if (current.get("shape") instanceof Map<?, ?> m) {
+                for (Map.Entry<?, ?> entry : m.entrySet()) {
+                    if (!(entry.getKey() instanceof String key) || !(entry.getValue() instanceof List<?> list)) continue;
+                    List<Double> parsed = new ArrayList<>();
+                    for (Object v : list) {
+                        if (v instanceof Number n) parsed.add(n.doubleValue());
+                    }
+                    if (parsed.size() == 6) shape.put(key, parsed);
+                }
+            }
+
+            return new DiaobanDisplayInfo(model, flipV, unit, leftSpace, rightSpace, texSize, tex, subModel, doorlight, shape);
         }
 
         public String getModel() {
@@ -124,6 +139,10 @@ public class DiaobanContent extends BaseContent {
 
         public Map<String, Object> getDoorlight() {
             return doorlight;
+        }
+
+        public Map<String, List<Double>> getShape() {
+            return shape;
         }
     }
 

--- a/common/src/main/java/com/fangsu/utils/ShapeSerializer.java
+++ b/common/src/main/java/com/fangsu/utils/ShapeSerializer.java
@@ -1,24 +1,27 @@
 package com.fangsu.utils;
 
 import com.fangsu.Main;
+import net.minecraft.world.level.block.Block;
 import net.minecraft.world.phys.shapes.Shapes;
 import net.minecraft.world.phys.shapes.VoxelShape;
-import net.minecraft.world.level.block.Block;
 
-import java.util.HashMap;
-import java.util.Map;
 import java.util.ArrayList;
+import java.util.HashMap;
+import java.util.LinkedHashMap;
 import java.util.List;
+import java.util.Map;
+import java.util.Objects;
 
 public class ShapeSerializer {
     private static final Map<String, VoxelShape> shapeMap = new HashMap<>();
 
     public static boolean isValid(String shape, int yRot) {
         if (shape == null || shape.isEmpty()) return false;
-        if (shapeMap.containsKey(shape)) return true;
+        String key = shape + "_" + yRot;
+        if (shapeMap.containsKey(key)) return true;
         try {
             VoxelShape v = parseShape(shape, yRot);
-            shapeMap.put(shape + "_" + yRot, v);
+            shapeMap.put(key, v);
             return true;
         } catch (Exception e) {
             Main.LOGGER.error("Error parsing shape: {}", shape, e);
@@ -35,6 +38,76 @@ public class ShapeSerializer {
             VoxelShape v = parseShape(shape, yRot);
             shapeMap.put(key, v);
             return v;
+        }
+    }
+
+    public static VoxelShape getShape(Object rawShape, int yRot) {
+        if (rawShape == null) return Shapes.empty();
+        if (rawShape instanceof String s) {
+            try {
+                return getShape(s, yRot);
+            } catch (Exception e) {
+                Main.LOGGER.warn("Invalid shape string: {}", s, e);
+                return Shapes.empty();
+            }
+        }
+        String serialized = serialize(rawShape);
+        if (serialized.isEmpty()) return Shapes.empty();
+        try {
+            return getShape(serialized, yRot);
+        } catch (Exception e) {
+            Main.LOGGER.warn("Invalid serialized shape: {}", serialized, e);
+            return Shapes.empty();
+        }
+    }
+
+    public static String serialize(Object rawShape) {
+        List<double[]> boxes = new ArrayList<>();
+        flattenBoxes(rawShape, boxes);
+        if (boxes.isEmpty()) return "";
+        StringBuilder sb = new StringBuilder();
+        for (int i = 0; i < boxes.size(); i++) {
+            if (i > 0) sb.append("/");
+            double[] b = boxes.get(i);
+            for (int j = 0; j < 6; j++) {
+                if (j > 0) sb.append(",");
+                sb.append(trimTrailingZero(b[j]));
+            }
+        }
+        return sb.toString();
+    }
+
+    private static String trimTrailingZero(double value) {
+        String text = Double.toString(value);
+        if (!text.contains(".")) return text;
+        int end = text.length();
+        while (end > 0 && text.charAt(end - 1) == '0') end--;
+        if (end > 0 && text.charAt(end - 1) == '.') end--;
+        return text.substring(0, end);
+    }
+
+    private static void flattenBoxes(Object raw, List<double[]> out) {
+        if (raw == null) return;
+        if (raw instanceof Map<?, ?> map) {
+            LinkedHashMap<String, Object> ordered = new LinkedHashMap<>();
+            for (Map.Entry<?, ?> e : map.entrySet()) {
+                ordered.put(Objects.toString(e.getKey(), ""), e.getValue());
+            }
+            ordered.keySet().stream().sorted().forEach(key -> flattenBoxes(ordered.get(key), out));
+            return;
+        }
+        if (raw instanceof List<?> list) {
+            if (list.size() == 6 && list.stream().allMatch(v -> v instanceof Number)) {
+                double[] box = new double[6];
+                for (int i = 0; i < 6; i++) {
+                    box[i] = ((Number) list.get(i)).doubleValue();
+                }
+                out.add(box);
+                return;
+            }
+            for (Object item : list) {
+                flattenBoxes(item, out);
+            }
         }
     }
 


### PR DESCRIPTION
### Motivation
- Add a flexible, serializable representation for collision/outline shapes so multi-part models can build final VoxelShapes at runtime and handle rotation/translation consistently.
- Replace ad-hoc CollisionBox handling with a central `ShapeSerializer` to support nested/map/list shape definitions from content JSON.

### Description
- Introduced `ShapeSerializer` with `serialize`, `getShape`, `isValid` and helpers to flatten nested shape definitions and cache rotated `VoxelShape`s keyed by serialized string and rotation.
- Diaoban: parsed and stored `shape` entries from content, serialized per-part shapes (`shapeLeftSerialized`, `shapeCenterSerialized`, `shapeRightSerialized`) and implemented `setCollisionShape`, `setShape` and runtime composition via `buildDiaobanShapeString` and `appendShapeWithOffset` to produce correct multi-unit shapes.
- TicketBarrier: stored serialized shapes for `shape`, `collisionShape`, `doorCloseShape` and `doorCloseCollisionShape`, added `resolveSerializedShape` and used serialized resolution in `buildOutlineShape` and `buildCollisionShape` with fallback to existing `CollisionBoxUtil` logic.
- ScreendoorGlass: refactored auto-selection logic in `recomputeAuto`, added `reloadModelAndShape` call to refresh models/shapes on recompute, persisted auto-resolved submodels during `whenSaving`, and added `whenUseWithBrush` to trigger auto-sync across neighbors.
- Diaoban content loader updated to read `shape` entries from JSON into `DiaobanDisplayInfo` and expose `getShape()`.

### Testing
- Ran a full project build with `./gradlew build`, which completed successfully.
- Ran the Gradle test task with `./gradlew test`; task completed without failures (no failing automated tests reported).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69dcf1490060832e86e55545131a43d8)