### PR TITLE
Eagerly load typed Content objects for PIDS / Diaoban / TicketBarrier

### DIFF
--- a/common/src/main/java/com/fangsu/blockEntities/BlockEntityDiaoban.java
+++ b/common/src/main/java/com/fangsu/blockEntities/BlockEntityDiaoban.java
@@ -101,26 +101,26 @@ public class BlockEntityDiaoban extends BaseObjBlockEntity implements IPlatformD
         reloadRoute();
 
         try {
-            DiaobanContent.DiaobanDisplayInfo displayInfo = ContentInfoUtil.getDiaobanDisplayInfo(mainModel, subModel);
-            if (displayInfo == null) {
+            DiaobanContent content = ContentInfoUtil.getDiaobanContent(mainModel, subModel);
+            if (content == null) {
                 markedError = true;
                 return;
             }
-            boolean flipV = displayInfo.isFlipV();
-            String modelKey = displayInfo.getModel();
+            boolean flipV = content.isFlipV();
+            String modelKey = content.getModel();
             Map<String, DynamicModelHolder> models = ResourceUtil.loadPartedDmh(new ResourceLocation(modelKey), flipV);
             String modelKeyLeft = "l", modelKeyCenter = "center", modelKeyRight = "r", modelKeyDlOn = "", modelKeyDlOff = "";
-            Map<String, String> subModelMap = displayInfo.getSubModel();
+            Map<String, String> subModelMap = content.getSubModel();
             if (subModelMap.containsKey("left")) modelKeyLeft = subModelMap.get("left");
             if (subModelMap.containsKey("center")) modelKeyCenter = subModelMap.get("center");
             if (subModelMap.containsKey("right")) modelKeyRight = subModelMap.get("right");
 
-            Map<String, Object> doorlightMap = displayInfo.getDoorlight();
+            Map<String, String> doorlightMap = content.getDoorlight();
             if (!doorlightMap.isEmpty()) {
-                if (doorlightMap.get("on") != null) modelKeyDlOn = doorlightMap.get("on").toString();
-                if (doorlightMap.get("off") != null) modelKeyDlOff = doorlightMap.get("off").toString();
+                if (doorlightMap.get("on") != null) modelKeyDlOn = doorlightMap.get("on");
+                if (doorlightMap.get("off") != null) modelKeyDlOff = doorlightMap.get("off");
                 if (doorlightMap.get("type") != null) {
-                    String rawType = doorlightMap.get("type").toString();
+                    String rawType = doorlightMap.get("type");
                     doorLightType = switch (rawType) {
                         case "common", "simple" -> 0;
                         case "blink" -> 1;
@@ -134,10 +134,10 @@ public class BlockEntityDiaoban extends BaseObjBlockEntity implements IPlatformD
             if (!"".equals(modelKeyDlOn)) dmhDlOn = models.get(modelKeyDlOn);
             if (!"".equals(modelKeyDlOff)) dmhDlOff = models.get(modelKeyDlOff);
 
-            double leftSpace = displayInfo.getLeftSpace(), rightSpace = displayInfo.getRightSpace();
+            double leftSpace = content.getLeftSpace(), rightSpace = content.getRightSpace();
             double y1 = 0.75, z1 = 0.25, y2 = 0.25, z2 = 0.25;
-            unit = displayInfo.getUnit();
-            List<List<Double>> tex = displayInfo.getTex();
+            unit = content.getUnit();
+            List<List<Double>> tex = content.getTex();
             if (!tex.isEmpty()) {
                 List<?> l = tex;
                 if (l.size() == 2) {
@@ -168,11 +168,11 @@ public class BlockEntityDiaoban extends BaseObjBlockEntity implements IPlatformD
             dispRawModel.generateNormals();
             dmhDisp.uploadLater(dispRawModel);
 
-            int texSize = displayInfo.getTexSize();
+            int texSize = content.getTexSize();
             texW = texSize * length + 1;
             texH = texSize;
 
-            Map<String, List<Double>> shapeMap = displayInfo.getShape();
+            Map<String, List<Double>> shapeMap = content.getShape();
             shapeLeftSerialized = ShapeSerializer.serialize(shapeMap.get("left"));
             shapeCenterSerialized = ShapeSerializer.serialize(shapeMap.get("center"));
             shapeRightSerialized = ShapeSerializer.serialize(shapeMap.get("right"));

--- a/common/src/main/java/com/fangsu/blockEntities/BlockEntityPids.java
+++ b/common/src/main/java/com/fangsu/blockEntities/BlockEntityPids.java
@@ -77,24 +77,24 @@ public class BlockEntityPids extends BaseObjBlockEntity {
         }
 
         try {
-            PidsContent.PidsDisplayInfo displayInfo = ContentInfoUtil.getPidsDisplayInfo(mainModel, subModel);
-            if (displayInfo == null) {
+            PidsContent content = ContentInfoUtil.getPidsContent(mainModel, subModel);
+            if (content == null) {
                 markedError = true;
                 return;
             }
-            List<Integer> texSize = displayInfo.getTexSize();
+            List<Integer> texSize = content.getTexSize();
             texW = texSize.size() > 0 ? texSize.get(0) : 128;
             texH = texSize.size() > 1 ? texSize.get(1) : 128;
             Main.LOGGER.info("texW={}, texH={}", texW, texH);
-            if (!displayInfo.getScript().isEmpty()) {
-                initScriptDrawingAsync(displayInfo.getScript());
+            if (!content.getScript().isEmpty()) {
+                initScriptDrawingAsync(content.getScript());
             }
-            boolean flipV = displayInfo.isFlipV();
-            String model = displayInfo.getModel();
+            boolean flipV = content.isFlipV();
+            String model = content.getModel();
             dmhMain = ResourceUtil.loadDmh(new ResourceLocation(model), flipV);
-            if (!displayInfo.getSlots().isEmpty()) {
+            if (!content.getSlots().isEmpty()) {
                 RawMeshBuilder builder = new RawMeshBuilder(4, "light", new ResourceLocation("fangsu:pids/black.png"));
-                for (List<List<Double>> currentSlot : displayInfo.getSlots()) {
+                for (List<List<Double>> currentSlot : content.getSlots()) {
                     List<List<Double>> finalList = new ArrayList<>();
                     for (List<Double> point : currentSlot) {
                         if (point.size() == 3) finalList.add(point);
@@ -110,8 +110,8 @@ public class BlockEntityPids extends BaseObjBlockEntity {
                 dispRawModel.generateNormals();
                 dmhDisp.uploadLater(dispRawModel);
             }
-            if (displayInfo.getShape() != null) {
-                this.shape = new CollisionBoxUtil.CollisionBox(displayInfo.getShape());
+            if (!content.getShape().isEmpty()) {
+                this.shape = new CollisionBoxUtil.CollisionBox(content.getShape());
             }
         } catch (Exception e) {
             Main.LOGGER.warn(e.getMessage());

--- a/common/src/main/java/com/fangsu/blockEntities/BlockEntityTicketBarrier.java
+++ b/common/src/main/java/com/fangsu/blockEntities/BlockEntityTicketBarrier.java
@@ -85,41 +85,41 @@ public class BlockEntityTicketBarrier extends BaseObjBlockEntity {
         String subModel = CustomItemHelper.checkSubModel(this, "subModel", DEFAULT_SUB_MODEL);
 
         try {
-            TicketBarrierContent.TicketBarrierDisplayInfo displayInfo = ContentInfoUtil.getTicketBarrierDisplayInfo(mainModel, subModel);
-            if (displayInfo == null) {
+            TicketBarrierContent content = ContentInfoUtil.getTicketBarrierContent(mainModel, subModel);
+            if (content == null) {
                 markedError = true;
                 return;
             }
-            mainDmh = ResourceUtil.loadDmh(new ResourceLocation(displayInfo.getModel()), displayInfo.isFlipV());
-            for (TicketBarrierContent.TicketBarrierDoorInfo doorInfo : displayInfo.getDoors()) {
+            mainDmh = ResourceUtil.loadDmh(new ResourceLocation(content.getModel()), content.getFilpV());
+            for (TicketBarrierContent.TicketBarrierDoorInfo doorInfo : content.getDoors()) {
                 subInfo = new TicketBarrierDoorRenderInfo(doorInfo);
             }
 
-            if (displayInfo.getShape() != null) {
-                shape = new CollisionBoxUtil.CollisionBox(displayInfo.getShape());
+            if (!content.getShape().isEmpty()) {
+                shape = new CollisionBoxUtil.CollisionBox(content.getShape());
             }
-            if (displayInfo.getCollisionShape() != null) {
-                collisionShape = new CollisionBoxUtil.CollisionBox(displayInfo.getCollisionShape());
+            if (!content.getCollisionShape().isEmpty()) {
+                collisionShape = new CollisionBoxUtil.CollisionBox(content.getCollisionShape());
             } else {
                 collisionShape = new CollisionBoxUtil.CollisionBox(List.of(List.of(-1, 0, 0, 1, 24, 16), List.of(15, 0, 0, 17, 24, 16)));
             }
-            if (displayInfo.getDoorCloseShape() != null) {
-                doorCloseShape = new CollisionBoxUtil.CollisionBox(displayInfo.getDoorCloseShape());
+            if (!content.getDoorCloseShape().isEmpty()) {
+                doorCloseShape = new CollisionBoxUtil.CollisionBox(content.getDoorCloseShape());
             }
-            if (displayInfo.getDoorCloseCollisionShape() != null) {
-                doorCloseCollisionShape = new CollisionBoxUtil.CollisionBox(displayInfo.getDoorCloseCollisionShape());
+            if (!content.getDoorCloseCollisionShape().isEmpty()) {
+                doorCloseCollisionShape = new CollisionBoxUtil.CollisionBox(content.getDoorCloseCollisionShape());
             } else {
                 doorCloseCollisionShape = new CollisionBoxUtil.CollisionBox(List.of(List.of(1, 0, 12, 15, 24, 15)));
             }
-            shapeSerialized = ShapeSerializer.serialize(displayInfo.getShape());
-            collisionShapeSerialized = ShapeSerializer.serialize(displayInfo.getCollisionShape());
-            doorCloseShapeSerialized = ShapeSerializer.serialize(displayInfo.getDoorCloseShape());
-            doorCloseCollisionShapeSerialized = ShapeSerializer.serialize(displayInfo.getDoorCloseCollisionShape());
+            shapeSerialized = ShapeSerializer.serialize(content.getShape());
+            collisionShapeSerialized = ShapeSerializer.serialize(content.getCollisionShape());
+            doorCloseShapeSerialized = ShapeSerializer.serialize(content.getDoorCloseShape());
+            doorCloseCollisionShapeSerialized = ShapeSerializer.serialize(content.getDoorCloseCollisionShape());
 
-            gatePos = displayInfo.getGatePos() != null ? displayInfo.getGatePos().floatValue() : 0.5f;
+            gatePos = content.getGatePos() != null ? content.getGatePos().floatValue() : 0.5f;
 
-            cardBox = parseBox(displayInfo.getCardBox());
-            ticketBox = parseBox(displayInfo.getTicketBox());
+            cardBox = parseBox(content.getCardBox());
+            ticketBox = parseBox(content.getTicketBox());
         } catch (Exception e) {
             Main.LOGGER.warn(e.getMessage());
         }

--- a/common/src/main/java/com/fangsu/customItem/CustomItems.java
+++ b/common/src/main/java/com/fangsu/customItem/CustomItems.java
@@ -58,7 +58,13 @@ public class CustomItems {
             long contentBegin = System.currentTimeMillis();
             List<ModelSelectInfo> thisItemInfo = getModelSelectInfos(value);
             items.put(key, thisItemInfo);
-            ContentInfoUtil.preloadByType(key, thisItemInfo);
+            if (cm.canLoadType(key)) {
+                for (ModelSelectInfo modelSelectInfo : thisItemInfo) {
+                    cm.loadItem(key, modelSelectInfo.content());
+                }
+            } else {
+                ContentInfoUtil.preloadByType(key, thisItemInfo);
+            }
             Main.LOGGER.debug("Loaded content {} in {} ms", key, System.currentTimeMillis() - contentBegin);
         }
         Main.LOGGER.info("Loaded {} items in {} ms", items.size(), System.currentTimeMillis() - begin);

--- a/common/src/main/java/com/fangsu/customItem/contents/ContentManager.java
+++ b/common/src/main/java/com/fangsu/customItem/contents/ContentManager.java
@@ -64,6 +64,23 @@ public class ContentManager {
         loaders.put(type, constructor);
     }
 
+    public boolean canLoadType(String type) {
+        return loaders.containsKey(type);
+    }
+
+    public <T extends BaseContent> T getContentById(String type, String path, String id, Class<T> clazz) {
+        Map<String, List<BaseContent>> typeMap = contents.get(type);
+        if (typeMap == null) return null;
+        List<BaseContent> contentList = typeMap.get(path);
+        if (contentList == null) return null;
+        for (BaseContent content : contentList) {
+            if (content != null && id.equals(content.getId()) && clazz.isInstance(content)) {
+                return clazz.cast(content);
+            }
+        }
+        return null;
+    }
+
     protected void addContent(String type, String path, BaseContent content) {
         if (contents == null) return;
         if (contents.containsKey(type)) {

--- a/common/src/main/java/com/fangsu/customItem/contents/DiaobanContent.java
+++ b/common/src/main/java/com/fangsu/customItem/contents/DiaobanContent.java
@@ -13,11 +13,79 @@ import java.util.Map;
 public class DiaobanContent extends BaseContent {
     private final String model;
     private final boolean flipV;
+    private final int unit;
+    private final double leftSpace;
+    private final double rightSpace;
+    private final int texSize;
+    private final List<List<Double>> tex;
+    private final Map<String, String> subModel;
+    private final Map<String, String> doorlight;
+    private final Map<String, List<Double>> shape;
 
     private DiaobanContent(JsonObject json) {
         super(json);
         model = json.get("model").getAsString();
         flipV = json.has("flipV") && json.get("flipV").getAsBoolean();
+        unit = json.has("unit") ? json.get("unit").getAsInt() : 8;
+        leftSpace = json.has("left_space") ? json.get("left_space").getAsDouble() : 0;
+        rightSpace = json.has("right_space") ? json.get("right_space").getAsDouble() : 0;
+        texSize = json.has("texSize") ? json.get("texSize").getAsInt() : 64;
+
+        tex = new ArrayList<>();
+        if (json.has("tex") && json.get("tex").isJsonArray()) {
+            for (JsonElement lineElement : json.getAsJsonArray("tex")) {
+                if (lineElement == null || !lineElement.isJsonArray()) continue;
+                List<Double> line = new ArrayList<>();
+                for (JsonElement valueElement : lineElement.getAsJsonArray()) {
+                    if (valueElement != null && valueElement.isJsonPrimitive() && valueElement.getAsJsonPrimitive().isNumber()) {
+                        line.add(valueElement.getAsDouble());
+                    }
+                }
+                if (!line.isEmpty()) {
+                    tex.add(line);
+                }
+            }
+        }
+
+        subModel = new HashMap<>();
+        if (json.has("subModel") && json.get("subModel").isJsonObject()) {
+            JsonObject subModelObject = json.getAsJsonObject("subModel");
+            for (Map.Entry<String, JsonElement> entry : subModelObject.entrySet()) {
+                JsonElement value = entry.getValue();
+                if (value != null && value.isJsonPrimitive()) {
+                    subModel.put(entry.getKey(), value.getAsString());
+                }
+            }
+        }
+
+        doorlight = new HashMap<>();
+        if (json.has("doorlight") && json.get("doorlight").isJsonObject()) {
+            JsonObject doorlightObject = json.getAsJsonObject("doorlight");
+            for (Map.Entry<String, JsonElement> entry : doorlightObject.entrySet()) {
+                JsonElement value = entry.getValue();
+                if (value != null && value.isJsonPrimitive()) {
+                    doorlight.put(entry.getKey(), value.getAsString());
+                }
+            }
+        }
+
+        shape = new HashMap<>();
+        if (json.has("shape") && json.get("shape").isJsonObject()) {
+            JsonObject shapeObject = json.getAsJsonObject("shape");
+            for (Map.Entry<String, JsonElement> entry : shapeObject.entrySet()) {
+                JsonElement value = entry.getValue();
+                if (value == null || !value.isJsonArray()) continue;
+                List<Double> box = new ArrayList<>();
+                for (JsonElement boxValue : value.getAsJsonArray()) {
+                    if (boxValue != null && boxValue.isJsonPrimitive() && boxValue.getAsJsonPrimitive().isNumber()) {
+                        box.add(boxValue.getAsDouble());
+                    }
+                }
+                if (!box.isEmpty()) {
+                    shape.put(entry.getKey(), box);
+                }
+            }
+        }
     }
 
     public String getModel() {
@@ -28,122 +96,36 @@ public class DiaobanContent extends BaseContent {
         return flipV;
     }
 
-    public static class DiaobanDisplayInfo {
-        private final String model;
-        private final boolean flipV;
-        private final int unit;
-        private final double leftSpace;
-        private final double rightSpace;
-        private final int texSize;
-        private final List<List<Double>> tex;
-        private final Map<String, String> subModel;
-        private final Map<String, Object> doorlight;
-        private final Map<String, List<Double>> shape;
+    public int getUnit() {
+        return unit;
+    }
 
-        private DiaobanDisplayInfo(String model, boolean flipV, int unit, double leftSpace, double rightSpace, int texSize,
-                                   List<List<Double>> tex, Map<String, String> subModel, Map<String, Object> doorlight,
-                                   Map<String, List<Double>> shape) {
-            this.model = model;
-            this.flipV = flipV;
-            this.unit = unit;
-            this.leftSpace = leftSpace;
-            this.rightSpace = rightSpace;
-            this.texSize = texSize;
-            this.tex = tex;
-            this.subModel = subModel;
-            this.doorlight = doorlight;
-            this.shape = shape;
-        }
+    public double getLeftSpace() {
+        return leftSpace;
+    }
 
-        public static DiaobanDisplayInfo fromMap(Map<String, Object> current) {
-            if (current == null || !(current.get("model") instanceof String model)) return null;
+    public double getRightSpace() {
+        return rightSpace;
+    }
 
-            boolean flipV = current.get("flipV") instanceof Boolean b && b;
-            int unit = current.get("unit") instanceof Number n ? n.intValue() : 8;
-            double leftSpace = current.get("left_space") instanceof Number n ? n.doubleValue() : 0;
-            double rightSpace = current.get("right_space") instanceof Number n ? n.doubleValue() : 0;
-            int texSize = current.get("texSize") instanceof Number n ? n.intValue() : 64;
+    public int getTexSize() {
+        return texSize;
+    }
 
-            List<List<Double>> tex = new ArrayList<>();
-            if (current.get("tex") instanceof List<?> texRaw) {
-                for (Object line : texRaw) {
-                    if (!(line instanceof List<?> lineList)) continue;
-                    List<Double> parsed = new ArrayList<>();
-                    for (Object v : lineList) {
-                        if (v instanceof Number n) parsed.add(n.doubleValue());
-                    }
-                    if (!parsed.isEmpty()) tex.add(parsed);
-                }
-            }
+    public List<List<Double>> getTex() {
+        return tex;
+    }
 
-            Map<String, String> subModel = new HashMap<>();
-            if (current.get("subModel") instanceof Map<?, ?> m) {
-                if (m.get("left") instanceof String s) subModel.put("left", s);
-                if (m.get("center") instanceof String s) subModel.put("center", s);
-                if (m.get("right") instanceof String s) subModel.put("right", s);
-            }
+    public Map<String, String> getSubModel() {
+        return subModel;
+    }
 
-            Map<String, Object> doorlight = new HashMap<>();
-            if (current.get("doorlight") instanceof Map<?, ?> m) {
-                if (m.get("on") instanceof String s) doorlight.put("on", s);
-                if (m.get("off") instanceof String s) doorlight.put("off", s);
-                if (m.get("type") instanceof String s) doorlight.put("type", s);
-            }
+    public Map<String, String> getDoorlight() {
+        return doorlight;
+    }
 
-            Map<String, List<Double>> shape = new HashMap<>();
-            if (current.get("shape") instanceof Map<?, ?> m) {
-                for (Map.Entry<?, ?> entry : m.entrySet()) {
-                    if (!(entry.getKey() instanceof String key) || !(entry.getValue() instanceof List<?> list)) continue;
-                    List<Double> parsed = new ArrayList<>();
-                    for (Object v : list) {
-                        if (v instanceof Number n) parsed.add(n.doubleValue());
-                    }
-                    if (parsed.size() == 6) shape.put(key, parsed);
-                }
-            }
-
-            return new DiaobanDisplayInfo(model, flipV, unit, leftSpace, rightSpace, texSize, tex, subModel, doorlight, shape);
-        }
-
-        public String getModel() {
-            return model;
-        }
-
-        public boolean isFlipV() {
-            return flipV;
-        }
-
-        public int getUnit() {
-            return unit;
-        }
-
-        public double getLeftSpace() {
-            return leftSpace;
-        }
-
-        public double getRightSpace() {
-            return rightSpace;
-        }
-
-        public int getTexSize() {
-            return texSize;
-        }
-
-        public List<List<Double>> getTex() {
-            return tex;
-        }
-
-        public Map<String, String> getSubModel() {
-            return subModel;
-        }
-
-        public Map<String, Object> getDoorlight() {
-            return doorlight;
-        }
-
-        public Map<String, List<Double>> getShape() {
-            return shape;
-        }
+    public Map<String, List<Double>> getShape() {
+        return shape;
     }
 
     protected static class DiaobanLoader extends BaseLoader {

--- a/common/src/main/java/com/fangsu/customItem/contents/PidsContent.java
+++ b/common/src/main/java/com/fangsu/customItem/contents/PidsContent.java
@@ -12,11 +12,64 @@ import java.util.Map;
 public class PidsContent extends BaseContent {
     private final String model;
     private final boolean flipV;
+    private final String script;
+    private final List<Integer> texSize;
+    private final List<List<List<Double>>> slots;
+    private final List<List<Double>> shape;
 
     private PidsContent(JsonObject json) {
         super(json);
         model = json.get("model").getAsString();
         flipV = json.has("flipV") && json.get("flipV").getAsBoolean();
+        script = json.has("script") ? json.get("script").getAsString() : "";
+
+        texSize = new ArrayList<>();
+        if (json.has("texSize") && json.get("texSize").isJsonArray()) {
+            for (JsonElement element : json.getAsJsonArray("texSize")) {
+                if (element != null && element.isJsonPrimitive() && element.getAsJsonPrimitive().isNumber()) {
+                    texSize.add(element.getAsInt());
+                }
+            }
+        }
+
+        slots = new ArrayList<>();
+        if (json.has("slots") && json.get("slots").isJsonArray()) {
+            for (JsonElement slotElement : json.getAsJsonArray("slots")) {
+                if (slotElement == null || !slotElement.isJsonArray()) continue;
+                List<List<Double>> quad = new ArrayList<>();
+                for (JsonElement pointElement : slotElement.getAsJsonArray()) {
+                    if (pointElement == null || !pointElement.isJsonArray()) continue;
+                    List<Double> point = new ArrayList<>();
+                    for (JsonElement valueElement : pointElement.getAsJsonArray()) {
+                        if (valueElement != null && valueElement.isJsonPrimitive() && valueElement.getAsJsonPrimitive().isNumber()) {
+                            point.add(valueElement.getAsDouble());
+                        }
+                    }
+                    if (point.size() == 3) {
+                        quad.add(point);
+                    }
+                }
+                if (!quad.isEmpty()) {
+                    slots.add(quad);
+                }
+            }
+        }
+
+        shape = new ArrayList<>();
+        if (json.has("shape") && json.get("shape").isJsonArray()) {
+            for (JsonElement shapeElement : json.getAsJsonArray("shape")) {
+                if (shapeElement == null || !shapeElement.isJsonArray()) continue;
+                List<Double> box = new ArrayList<>();
+                for (JsonElement valueElement : shapeElement.getAsJsonArray()) {
+                    if (valueElement != null && valueElement.isJsonPrimitive() && valueElement.getAsJsonPrimitive().isNumber()) {
+                        box.add(valueElement.getAsDouble());
+                    }
+                }
+                if (!box.isEmpty()) {
+                    shape.add(box);
+                }
+            }
+        }
     }
 
     public String getModel() {
@@ -27,79 +80,20 @@ public class PidsContent extends BaseContent {
         return flipV;
     }
 
-    public static class PidsDisplayInfo {
-        private final String model;
-        private final boolean flipV;
-        private final String script;
-        private final List<Integer> texSize;
-        private final List<List<List<Double>>> slots;
-        private final List<?> shape;
+    public String getScript() {
+        return script;
+    }
 
-        private PidsDisplayInfo(String model, boolean flipV, String script, List<Integer> texSize, List<List<List<Double>>> slots, List<?> shape) {
-            this.model = model;
-            this.flipV = flipV;
-            this.script = script;
-            this.texSize = texSize;
-            this.slots = slots;
-            this.shape = shape;
-        }
+    public List<Integer> getTexSize() {
+        return texSize;
+    }
 
-        public static PidsDisplayInfo fromMap(Map<String, Object> current) {
-            if (current == null || !(current.get("model") instanceof String model)) return null;
-            boolean flipV = current.get("flipV") instanceof Boolean b && b;
-            String script = current.get("script") instanceof String s ? s : "";
+    public List<List<List<Double>>> getSlots() {
+        return slots;
+    }
 
-            List<Integer> texSize = new ArrayList<>();
-            if (current.get("texSize") instanceof List<?> l) {
-                for (Object o : l) {
-                    if (o instanceof Number n) texSize.add(n.intValue());
-                }
-            }
-
-            List<List<List<Double>>> slots = new ArrayList<>();
-            if (current.get("slots") instanceof List<?> slotList) {
-                for (Object slot : slotList) {
-                    if (!(slot instanceof List<?> quadList)) continue;
-                    List<List<Double>> quad = new ArrayList<>();
-                    for (Object point : quadList) {
-                        if (!(point instanceof List<?> pointRaw)) continue;
-                        List<Double> pos = new ArrayList<>();
-                        for (Object value : pointRaw) {
-                            if (value instanceof Number n) pos.add(n.doubleValue());
-                        }
-                        if (pos.size() == 3) quad.add(pos);
-                    }
-                    if (!quad.isEmpty()) slots.add(quad);
-                }
-            }
-
-            List<?> shape = current.get("shape") instanceof List<?> s ? s : null;
-            return new PidsDisplayInfo(model, flipV, script, texSize, slots, shape);
-        }
-
-        public String getModel() {
-            return model;
-        }
-
-        public boolean isFlipV() {
-            return flipV;
-        }
-
-        public String getScript() {
-            return script;
-        }
-
-        public List<Integer> getTexSize() {
-            return texSize;
-        }
-
-        public List<List<List<Double>>> getSlots() {
-            return slots;
-        }
-
-        public List<?> getShape() {
-            return shape;
-        }
+    public List<List<Double>> getShape() {
+        return shape;
     }
 
     protected static class PidsLoader extends BaseLoader {

--- a/common/src/main/java/com/fangsu/customItem/contents/TicketBarrierContent.java
+++ b/common/src/main/java/com/fangsu/customItem/contents/TicketBarrierContent.java
@@ -13,12 +13,27 @@ import java.util.Map;
 public class TicketBarrierContent extends BaseContent {
     private final String model;
     private final boolean filpV;
+    private final List<TicketBarrierDoorInfo> doors;
+    private final List<List<Double>> shape;
+    private final List<List<Double>> collisionShape;
+    private final List<List<Double>> doorCloseShape;
+    private final List<List<Double>> doorCloseCollisionShape;
+    private final Double gatePos;
+    private final List<Double> cardBox;
+    private final List<Double> ticketBox;
 
     private TicketBarrierContent(JsonObject json) {
         super(json);
         model = json.get("model").getAsString();
         filpV = json.has("flipV") && json.get("flipV").getAsBoolean();
-
+        doors = parseDoors(json.get("doors"));
+        shape = parseBoxList(json.get("shape"));
+        collisionShape = parseBoxList(json.get("collisionShape"));
+        doorCloseShape = parseBoxList(json.get("doorCloseShape"));
+        doorCloseCollisionShape = parseBoxList(json.get("doorCloseCollisionShape"));
+        gatePos = json.has("gatePos") ? json.get("gatePos").getAsDouble() : null;
+        cardBox = parseSingleBox(json.get("cardBox"));
+        ticketBox = parseSingleBox(json.get("ticketBox"));
     }
 
     public String getModel() {
@@ -29,65 +44,76 @@ public class TicketBarrierContent extends BaseContent {
         return filpV;
     }
 
-    public static class TicketBarrierDisplayInfo {
-        private final String model;
-        private final boolean flipV;
-        private final List<TicketBarrierDoorInfo> doors;
-        private final List<?> shape;
-        private final List<?> collisionShape;
-        private final List<?> doorCloseShape;
-        private final List<?> doorCloseCollisionShape;
-        private final Number gatePos;
-        private final List<?> cardBox;
-        private final List<?> ticketBox;
+    public List<TicketBarrierDoorInfo> getDoors() {
+        return doors;
+    }
 
-        private TicketBarrierDisplayInfo(String model, boolean flipV, List<TicketBarrierDoorInfo> doors, List<?> shape,
-                                         List<?> collisionShape, List<?> doorCloseShape, List<?> doorCloseCollisionShape,
-                                         Number gatePos, List<?> cardBox, List<?> ticketBox) {
-            this.model = model;
-            this.flipV = flipV;
-            this.doors = doors;
-            this.shape = shape;
-            this.collisionShape = collisionShape;
-            this.doorCloseShape = doorCloseShape;
-            this.doorCloseCollisionShape = doorCloseCollisionShape;
-            this.gatePos = gatePos;
-            this.cardBox = cardBox;
-            this.ticketBox = ticketBox;
+    public List<List<Double>> getShape() {
+        return shape;
+    }
+
+    public List<List<Double>> getCollisionShape() {
+        return collisionShape;
+    }
+
+    public List<List<Double>> getDoorCloseShape() {
+        return doorCloseShape;
+    }
+
+    public List<List<Double>> getDoorCloseCollisionShape() {
+        return doorCloseCollisionShape;
+    }
+
+    public Double getGatePos() {
+        return gatePos;
+    }
+
+    public List<Double> getCardBox() {
+        return cardBox;
+    }
+
+    public List<Double> getTicketBox() {
+        return ticketBox;
+    }
+
+    private static List<TicketBarrierDoorInfo> parseDoors(JsonElement doorsElement) {
+        List<TicketBarrierDoorInfo> parsed = new ArrayList<>();
+        if (doorsElement == null || !doorsElement.isJsonArray()) return parsed;
+        for (JsonElement doorElement : doorsElement.getAsJsonArray()) {
+            if (doorElement == null || !doorElement.isJsonObject()) continue;
+            TicketBarrierDoorInfo info = TicketBarrierDoorInfo.fromJson(doorElement.getAsJsonObject());
+            if (info != null) parsed.add(info);
         }
+        return parsed;
+    }
 
-        public static TicketBarrierDisplayInfo fromMap(Map<String, Object> current) {
-            if (current == null || !(current.get("model") instanceof String model)) return null;
-            boolean flipV = current.get("flipV") instanceof Boolean b && b;
-            List<TicketBarrierDoorInfo> doors = new ArrayList<>();
-            if (current.get("doors") instanceof List<?> doorList) {
-                for (Object door : doorList) {
-                    if (door instanceof Map<?, ?> d) {
-                        TicketBarrierDoorInfo doorInfo = TicketBarrierDoorInfo.fromMap(d);
-                        if (doorInfo != null) doors.add(doorInfo);
-                    }
+    private static List<List<Double>> parseBoxList(JsonElement element) {
+        List<List<Double>> parsed = new ArrayList<>();
+        if (element == null || !element.isJsonArray()) return parsed;
+        for (JsonElement boxElement : element.getAsJsonArray()) {
+            if (boxElement == null || !boxElement.isJsonArray()) continue;
+            List<Double> box = new ArrayList<>();
+            for (JsonElement valueElement : boxElement.getAsJsonArray()) {
+                if (valueElement != null && valueElement.isJsonPrimitive() && valueElement.getAsJsonPrimitive().isNumber()) {
+                    box.add(valueElement.getAsDouble());
                 }
             }
-            List<?> shape = current.get("shape") instanceof List<?> s ? s : null;
-            List<?> collisionShape = current.get("collisionShape") instanceof List<?> s ? s : null;
-            List<?> doorCloseShape = current.get("doorCloseShape") instanceof List<?> s ? s : null;
-            List<?> doorCloseCollisionShape = current.get("doorCloseCollisionShape") instanceof List<?> s ? s : null;
-            Number gatePos = current.get("gatePos") instanceof Number n ? n : null;
-            List<?> cardBox = current.get("cardBox") instanceof List<?> s ? s : null;
-            List<?> ticketBox = current.get("ticketBox") instanceof List<?> s ? s : null;
-            return new TicketBarrierDisplayInfo(model, flipV, doors, shape, collisionShape, doorCloseShape, doorCloseCollisionShape, gatePos, cardBox, ticketBox);
+            if (!box.isEmpty()) {
+                parsed.add(box);
+            }
         }
+        return parsed;
+    }
 
-        public String getModel() { return model; }
-        public boolean isFlipV() { return flipV; }
-        public List<TicketBarrierDoorInfo> getDoors() { return doors; }
-        public List<?> getShape() { return shape; }
-        public List<?> getCollisionShape() { return collisionShape; }
-        public List<?> getDoorCloseShape() { return doorCloseShape; }
-        public List<?> getDoorCloseCollisionShape() { return doorCloseCollisionShape; }
-        public Number getGatePos() { return gatePos; }
-        public List<?> getCardBox() { return cardBox; }
-        public List<?> getTicketBox() { return ticketBox; }
+    private static List<Double> parseSingleBox(JsonElement element) {
+        if (element == null || !element.isJsonArray()) return null;
+        List<Double> parsed = new ArrayList<>();
+        for (JsonElement valueElement : element.getAsJsonArray()) {
+            if (valueElement != null && valueElement.isJsonPrimitive() && valueElement.getAsJsonPrimitive().isNumber()) {
+                parsed.add(valueElement.getAsDouble());
+            }
+        }
+        return parsed.isEmpty() ? null : parsed;
     }
 
     public static class TicketBarrierDoorInfo {
@@ -105,27 +131,19 @@ public class TicketBarrierContent extends BaseContent {
             this.doors = doors;
         }
 
-        public static TicketBarrierDoorInfo fromMap(Map<?, ?> baseMap) {
-            if (baseMap == null) {
+        public static TicketBarrierDoorInfo fromJson(JsonObject json) {
+            if (json == null || !json.has("model")) {
                 return null;
             }
-            Object modelObj = baseMap.get("model");
-            if (!(modelObj instanceof String modelPath)) {
-                return null;
-            }
-            boolean usePartedModel = Boolean.TRUE.equals(baseMap.get("use_parted_model"));
-            boolean flipV = Boolean.TRUE.equals(baseMap.get("flipV"));
-            int doorType = 1;
-            Object dtObj = baseMap.get("doorType");
-            if (dtObj instanceof Number num) {
-                doorType = num.intValue();
-            }
+            String modelPath = json.get("model").getAsString();
+            boolean usePartedModel = json.has("use_parted_model") && json.get("use_parted_model").getAsBoolean();
+            boolean flipV = json.has("flipV") && json.get("flipV").getAsBoolean();
+            int doorType = json.has("doorType") ? json.get("doorType").getAsInt() : 1;
             List<DoorInfo> doors = new ArrayList<>();
-            Object posObj = baseMap.get("pos");
-            if (posObj instanceof List<?> mapPos) {
-                for (Object posEntry : mapPos) {
-                    if (posEntry instanceof Map<?, ?> thisMap) {
-                        DoorInfo doorInfo = DoorInfo.fromMap(thisMap);
+            if (json.has("pos") && json.get("pos").isJsonArray()) {
+                for (JsonElement posEntry : json.getAsJsonArray("pos")) {
+                    if (posEntry != null && posEntry.isJsonObject()) {
+                        DoorInfo doorInfo = DoorInfo.fromJson(posEntry.getAsJsonObject());
                         if (doorInfo != null) {
                             doors.add(doorInfo);
                         }
@@ -182,35 +200,26 @@ public class TicketBarrierContent extends BaseContent {
                 this.step = step;
             }
 
-            public static DoorInfo fromMap(Map<?, ?> map) {
-                if (map == null) {
+            public static DoorInfo fromJson(JsonObject json) {
+                if (json == null || !json.has("subModel")) {
                     return null;
                 }
-                Object subModelObj = map.get("subModel");
-                if (!(subModelObj instanceof String subModel)) {
-                    return null;
-                }
-                Object posListObj = map.get("pos");
-                if (!(posListObj instanceof List<?> posList) || posList.isEmpty()) {
+                String subModel = json.get("subModel").getAsString();
+                if (!json.has("pos") || !json.get("pos").isJsonArray()) {
                     return null;
                 }
                 List<Double> pos = new ArrayList<>();
-                for (Object o : posList) {
-                    if (!(o instanceof Number n)) {
+                for (JsonElement posElement : json.getAsJsonArray("pos")) {
+                    if (posElement == null || !posElement.isJsonPrimitive() || !posElement.getAsJsonPrimitive().isNumber()) {
                         return null;
                     }
-                    pos.add(n.doubleValue());
+                    pos.add(posElement.getAsDouble());
                 }
-                int side = 0;
-                Object sideObj = map.get("side");
-                if (sideObj instanceof Number n) {
-                    side = n.intValue();
+                if (pos.isEmpty()) {
+                    return null;
                 }
-                double step = 1;
-                Object stepObj = map.get("step");
-                if (stepObj instanceof Number n) {
-                    step = n.doubleValue();
-                }
+                int side = json.has("side") ? json.get("side").getAsInt() : 0;
+                double step = json.has("step") ? json.get("step").getAsDouble() : 1;
                 return new DoorInfo(subModel, pos, side, step);
             }
 

--- a/common/src/main/java/com/fangsu/utils/ContentInfoUtil.java
+++ b/common/src/main/java/com/fangsu/utils/ContentInfoUtil.java
@@ -13,16 +13,16 @@ public final class ContentInfoUtil {
     private ContentInfoUtil() {
     }
 
-    public static PidsContent.PidsDisplayInfo getPidsDisplayInfo(String mainModel, String subModel) {
-        return PidsContent.PidsDisplayInfo.fromMap(CustomItems.getContentInfo(mainModel, "content", subModel));
+    public static PidsContent getPidsContent(String mainModel, String subModel) {
+        return ContentManager.getInstance().getContentById("pids", mainModel, subModel, PidsContent.class);
     }
 
-    public static DiaobanContent.DiaobanDisplayInfo getDiaobanDisplayInfo(String mainModel, String subModel) {
-        return DiaobanContent.DiaobanDisplayInfo.fromMap(CustomItems.getContentInfo(mainModel, "content", subModel));
+    public static DiaobanContent getDiaobanContent(String mainModel, String subModel) {
+        return ContentManager.getInstance().getContentById("diaoban", mainModel, subModel, DiaobanContent.class);
     }
 
-    public static TicketBarrierContent.TicketBarrierDisplayInfo getTicketBarrierDisplayInfo(String mainModel, String subModel) {
-        return TicketBarrierContent.TicketBarrierDisplayInfo.fromMap(CustomItems.getContentInfo(mainModel, "", subModel));
+    public static TicketBarrierContent getTicketBarrierContent(String mainModel, String subModel) {
+        return ContentManager.getInstance().getContentById("ticketBarrier", mainModel, subModel, TicketBarrierContent.class);
     }
 
     public static SignContent.SignDisplayInfo getSignDisplayInfo(String mainModel, String subModel) {


### PR DESCRIPTION
### Motivation
- Replace the previous map-based `dispInfo`/`fromMap` flow with content classes that directly hold parsed JSON data, so block entities can read complete data from Content objects instead of lazily reading from resource maps at runtime.
- Load content files once during initialization for types that have a registered loader to avoid later lookups from `ContentResourceLoader` maps and to simplify typed access from block entities.

### Description
- Refactored `PidsContent`, `DiaobanContent`, and `TicketBarrierContent` to parse and store their full display/configuration fields during construction (e.g. `script/texSize/slots/shape`, `unit/left_space/subModel/doorlight/shape`, doors/shape/collision/gate/card/ticket boxes). 
- Added `canLoadType(String)` and `getContentById(...)` to `ContentManager` to support eager loading and typed lookups of content instances.
- Updated `CustomItems.init()` to eagerly call `ContentManager.loadItem(...)` for loadable content types (when `canLoadType` is true) instead of only preloading resource maps.
- Reworked `ContentInfoUtil` to return typed content objects (`getPidsContent`, `getDiaobanContent`, `getTicketBarrierContent`) and updated `BlockEntityPids`, `BlockEntityDiaoban`, and `BlockEntityTicketBarrier` to consume the typed content fields directly (removed intermediate map->dispInfo conversion and adjusted shape/slot/script/model usages).

### Testing
- Attempted to compile the project with `./gradlew :common:compileJava -x test` to validate the Java changes, but the build failed due to the local toolchain/Gradle environment reporting `Unsupported class file major version 69`, so project compilation was not completed.
- Other repository-level checks performed: code modifications were applied and the changes were committed locally; no automated unit or integration tests were executed due to the compile environment issue.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69dd045dc050832e8aedbcb744dd29c9)