### PR TITLE
Compute dynamic voxel shapes for signs and add JS sign icon support

### DIFF
--- a/common/src/main/java/com/fangsu/blockEntities/BlockEntitySign.java
+++ b/common/src/main/java/com/fangsu/blockEntities/BlockEntitySign.java
@@ -22,6 +22,7 @@ import com.fangsu.utils.CustomItemHelper;
 import com.fangsu.utils.ResourceUtil;
 import com.google.gson.*;
 import net.minecraft.core.BlockPos;
+import net.minecraft.core.Direction;
 import net.minecraft.network.FriendlyByteBuf;
 import net.minecraft.network.chat.Component;
 import net.minecraft.resources.ResourceLocation;
@@ -31,6 +32,9 @@ import net.minecraft.world.entity.player.Player;
 import net.minecraft.world.level.Level;
 import net.minecraft.world.level.block.state.BlockState;
 import net.minecraft.world.phys.BlockHitResult;
+import net.minecraft.world.phys.Vec3;
+import net.minecraft.world.phys.shapes.Shapes;
+import net.minecraft.world.phys.shapes.VoxelShape;
 
 import java.awt.*;
 import java.util.ArrayList;
@@ -40,6 +44,7 @@ import java.util.Map;
 
 import com.fangsu.render.scripting.util.DynamicModelHolder;
 import com.fangsu.render.sowcer.math.Matrices;
+import com.fangsu.blocks.BaseObjBlock;
 
 import static com.fangsu.blocks.ModBlocks.BLOCK_ENTITY_SIGN;
 
@@ -400,6 +405,57 @@ public class BlockEntitySign extends BaseObjBlockEntity implements Syncable {
                 }
         ).setShowCondition((v) -> this.showRightPole && (!isMtrTheme)));
         return configs;
+    }
+
+    @Override
+    public VoxelShape setCollisionShape(BlockState state) {
+        return getFinalShape(state);
+    }
+
+    @Override
+    public VoxelShape setShape(BlockState state) {
+        return getFinalShape(state);
+    }
+
+    private VoxelShape getFinalShape(BlockState state) {
+        Direction facing = state.getValue(BaseObjBlock.FACING);
+        Vec3 trans = transformOffset(facing, new Vec3(translateX, translateY, translateZ));
+        float rotX = this.rotateX;
+        float rotY = this.rotateY + (float) Math.toRadians(-facing.toYRot());
+        float rotZ = this.rotateZ;
+        long posLong = worldPosition.asLong();
+
+        VoxelShape shape = Shapes.empty();
+        double startX = -0.5 * unit * length / 16d;
+        if (shapeLeft != null) {
+            VoxelShape s = CollisionBoxUtil.cachedRotatedShape(posLong, shapeLeft, Vec3.ZERO, rotX, rotY, rotZ, 0.1f);
+            shape = Shapes.or(shape, s.move(startX + trans.x, trans.y, trans.z));
+        }
+        for (int i = 0; i < length / (unit / 8d); i++) {
+            if (shapeCenter != null) {
+                double x = startX + unit / 32d + i * (unit / 16d);
+                VoxelShape s = CollisionBoxUtil.cachedRotatedShape(posLong, shapeCenter, Vec3.ZERO, rotX, rotY, rotZ, 0.1f);
+                shape = Shapes.or(shape, s.move(x + trans.x, trans.y, trans.z));
+            }
+        }
+        if (shapeRight != null) {
+            double x = startX + unit / 32d + (length / (unit / 8d)) * (unit / 16d) + unit / 32d;
+            VoxelShape s = CollisionBoxUtil.cachedRotatedShape(posLong, shapeRight, Vec3.ZERO, rotX, rotY, rotZ, 0.1f);
+            shape = Shapes.or(shape, s.move(x + trans.x, trans.y, trans.z));
+        }
+        if (shapePole != null) {
+            if (showLeftPole) {
+                double x = startX + leftPolePos / 16d + mtrPoleOffset / 16d;
+                VoxelShape s = CollisionBoxUtil.cachedRotatedShape(posLong, shapePole, Vec3.ZERO, rotX, rotY, rotZ, 0.1f);
+                shape = Shapes.or(shape, s.move(x + trans.x, trans.y, trans.z));
+            }
+            if (showRightPole) {
+                double x = startX + (unit * length - rightPolePos) / 16d - mtrPoleOffset / 16d;
+                VoxelShape s = CollisionBoxUtil.cachedRotatedShape(posLong, shapePole, Vec3.ZERO, rotX, rotY, rotZ, 0.1f);
+                shape = Shapes.or(shape, s.move(x + trans.x, trans.y, trans.z));
+            }
+        }
+        return shape;
     }
 
     @Override

--- a/common/src/main/java/com/fangsu/blockEntities/BlockEntitySignOnWall.java
+++ b/common/src/main/java/com/fangsu/blockEntities/BlockEntitySignOnWall.java
@@ -23,6 +23,7 @@ import com.fangsu.utils.CustomItemHelper;
 import com.fangsu.utils.ResourceUtil;
 import com.google.gson.*;
 import net.minecraft.core.BlockPos;
+import net.minecraft.core.Direction;
 import net.minecraft.network.FriendlyByteBuf;
 import net.minecraft.network.chat.Component;
 import net.minecraft.resources.ResourceLocation;
@@ -32,6 +33,9 @@ import net.minecraft.world.entity.player.Player;
 import net.minecraft.world.level.Level;
 import net.minecraft.world.level.block.state.BlockState;
 import net.minecraft.world.phys.BlockHitResult;
+import net.minecraft.world.phys.Vec3;
+import net.minecraft.world.phys.shapes.Shapes;
+import net.minecraft.world.phys.shapes.VoxelShape;
 
 import java.awt.*;
 import java.util.ArrayList;
@@ -40,6 +44,7 @@ import java.util.List;
 import java.util.Map;
 
 import static com.fangsu.blocks.ModBlocks.BLOCK_ENTITY_SIGN_ON_WALL;
+import com.fangsu.blocks.BaseObjBlock;
 
 public class BlockEntitySignOnWall extends BaseObjBlockEntity implements Syncable {
     private static final String DEFAULT_MAIN_MODEL = "fangsu:sign/beijing/beijing_sign.json";
@@ -222,6 +227,45 @@ public class BlockEntitySignOnWall extends BaseObjBlockEntity implements Syncabl
                 }
         ));
         return configs;
+    }
+
+    @Override
+    public VoxelShape setCollisionShape(BlockState state) {
+        return getFinalShape(state);
+    }
+
+    @Override
+    public VoxelShape setShape(BlockState state) {
+        return getFinalShape(state);
+    }
+
+    private VoxelShape getFinalShape(BlockState state) {
+        Direction facing = state.getValue(BaseObjBlock.FACING);
+        Vec3 trans = transformOffset(facing, new Vec3(translateX, translateY, translateZ));
+        float rotX = this.rotateX;
+        float rotY = this.rotateY + (float) Math.toRadians(-facing.toYRot());
+        float rotZ = this.rotateZ;
+        long posLong = worldPosition.asLong();
+
+        VoxelShape shape = Shapes.empty();
+        double startX = -0.5 * unit * length / 16d;
+        if (shapeLeft != null) {
+            VoxelShape s = CollisionBoxUtil.cachedRotatedShape(posLong, shapeLeft, Vec3.ZERO, rotX, rotY, rotZ, 0.1f);
+            shape = Shapes.or(shape, s.move(startX + trans.x, trans.y, trans.z));
+        }
+        for (int i = 0; i < length / (unit / 8d); i++) {
+            if (shapeCenter != null) {
+                double x = startX + unit / 32d + i * (unit / 16d);
+                VoxelShape s = CollisionBoxUtil.cachedRotatedShape(posLong, shapeCenter, Vec3.ZERO, rotX, rotY, rotZ, 0.1f);
+                shape = Shapes.or(shape, s.move(x + trans.x, trans.y, trans.z));
+            }
+        }
+        if (shapeRight != null) {
+            double x = startX + unit / 32d + (length / (unit / 8d)) * (unit / 16d) + unit / 32d;
+            VoxelShape s = CollisionBoxUtil.cachedRotatedShape(posLong, shapeRight, Vec3.ZERO, rotX, rotY, rotZ, 0.1f);
+            shape = Shapes.or(shape, s.move(x + trans.x, trans.y, trans.z));
+        }
+        return shape;
     }
 
     @Override

--- a/common/src/main/java/com/fangsu/drawing/sign/JsItem.java
+++ b/common/src/main/java/com/fangsu/drawing/sign/JsItem.java
@@ -18,6 +18,7 @@ import java.util.Map;
 public class JsItem extends SignItem {
     private final String id;
     private final ResourceLocation scriptLocation;
+    private final ResourceLocation iconLocation;
     private final List<JsonObject> configs;
     private ScriptHolderBase scriptHolder;
 
@@ -30,9 +31,14 @@ public class JsItem extends SignItem {
     private Map<String, Value> extra;
 
     public JsItem(String id, ResourceLocation scriptLocation, List<JsonObject> configs, JsonObject json) {
+        this(id, scriptLocation, null, configs, json);
+    }
+
+    public JsItem(String id, ResourceLocation scriptLocation, ResourceLocation iconLocation, List<JsonObject> configs, JsonObject json) {
         super();
         this.id = id;
         this.scriptLocation = scriptLocation;
+        this.iconLocation = iconLocation;
         this.configs = configs;
 
         ScriptManager scriptManager = ScriptManager.getInstance();
@@ -94,7 +100,7 @@ public class JsItem extends SignItem {
 
     @Override
     public ResourceLocation getIconLocation() {
-        return null;
+        return iconLocation;
     }
 
     @Override

--- a/common/src/main/java/com/fangsu/drawing/sign/SignItemFactory.java
+++ b/common/src/main/java/com/fangsu/drawing/sign/SignItemFactory.java
@@ -49,7 +49,7 @@ public final class SignItemFactory {
 
     public static void init() {
         registerBuiltInSign();
-//        registerJsItems();    //暂时不实装
+        registerJsItems();
         JsonElement builtInSign = ResourceUtil.loadAsJSON(new ResourceLocation("fangsu:sign/builtinsign.json"));
         if (builtInSign != null && builtInSign.isJsonObject()) {
             JsonObject obj = builtInSign.getAsJsonObject();
@@ -110,6 +110,7 @@ public final class SignItemFactory {
             if (!valueObject.has("content")) continue;
             String finalKey = "JS_" + key;
             String content = valueObject.getAsJsonPrimitive("content").getAsString();
+            ResourceLocation icon = valueObject.has("icon") ? new ResourceLocation(valueObject.getAsJsonPrimitive("icon").getAsString()) : null;
             if (valueObject.has("extraConfig")) {
                 List<JsonObject> configs = new ArrayList<>();
                 JsonElement extraConfig = valueObject.get("extraConfig");
@@ -132,11 +133,11 @@ public final class SignItemFactory {
                         configs.add(configObject);
                     }
                 }
-                REGISTRY.put(finalKey, json -> new JsItem(finalKey, new ResourceLocation(content), configs, json));
-                EDITOR_ITEMS.add(new JsItem(finalKey, new ResourceLocation(content), configs, new JsonObject()));
+                REGISTRY.put(finalKey, json -> new JsItem(finalKey, new ResourceLocation(content), icon, configs, json));
+                EDITOR_ITEMS.add(new JsItem(finalKey, new ResourceLocation(content), icon, configs, new JsonObject()));
             } else {
-                REGISTRY.put(finalKey, json -> new JsItem(finalKey, null, null, json));
-                EDITOR_ITEMS.add(new JsItem(finalKey, null, null, new JsonObject()));
+                REGISTRY.put(finalKey, json -> new JsItem(finalKey, null, icon, null, json));
+                EDITOR_ITEMS.add(new JsItem(finalKey, null, icon, null, new JsonObject()));
             }
         }
     }

--- a/common/src/main/resources/assets/fangsu/sign/mtr_sign/mtr_sign.json
+++ b/common/src/main/resources/assets/fangsu/sign/mtr_sign/mtr_sign.json
@@ -100,5 +100,26 @@
     }
   ],
   "on_wall": [
+    {
+      "id": "mtr_sign_on_wall_a",
+      "text": "fangsu.item.mtr_sign_on_wall_a",
+      "model": "fangsu:sign/mtr_sign/mtr_sign.obj",
+      "unit": 8,
+      "isMtrTheme": true,
+      "defaultBgColor": 0,
+      "tex": [
+        [0.0625, 0.06],
+        [0.5625, 0.06]
+      ],
+      "main": {
+        "subModel": "main",
+        "shape": [[4, 0, 7.25, 12, 6, 8.75]]
+      },
+      "side": {
+        "right": {"subModel": "sidea", "shape": [[8, 0, 7.25, 9, 6, 8.75]]},
+        "left": {"subModel": "sideb", "shape": [[7, 0, 7.25, 8, 6, 8.75]]}
+      },
+      "pole": {"subModel": "pole", "height": 0, "shape": []}
+    }
   ]
 }

--- a/common/src/main/resources/assets/fangsu/sign/script_sign.json
+++ b/common/src/main/resources/assets/fangsu/sign/script_sign.json
@@ -1,28 +1,29 @@
 {
-    "trainRoute": {
-        "text": "fangsu.scriptsign.route",
-        "content": "fangsu:diaoban/route.js",
-        "extraConfig": [
-            {
-                "type": "str",
-                "text": "cfg.sign.imgpath",
-                "savePos": "img",
-                "default": "",
-                "param": {
-                    "savePos": "img",
-                    "lines": 2
-                }
-            },
-            {
-                "type": "str",
-                "text": "cfg.sign.color",
-                "savePos": "color",
-                "default": "ABCDEF",
-                "param": {
-                    "savePos": "color",
-                    "lines": 1
-                }
-            }
-        ]
-    }
+  "trainRoute": {
+    "text": "fangsu.scriptsign.route",
+    "icon": "fangsu:sign/routea.png",
+    "content": "fangsu:diaoban/route.js",
+    "extraConfig": [
+      {
+        "type": "str",
+        "text": "cfg.sign.imgpath",
+        "savePos": "img",
+        "default": "",
+        "param": {
+          "savePos": "img",
+          "lines": 2
+        }
+      },
+      {
+        "type": "str",
+        "text": "cfg.sign.color",
+        "savePos": "color",
+        "default": "ABCDEF",
+        "param": {
+          "savePos": "color",
+          "lines": 1
+        }
+      }
+    ]
+  }
 }


### PR DESCRIPTION
### Motivation

- Ensure sign blocks provide accurate collision/interaction shapes based on model parts, orientation, length and pole positions.
- Enable script-based sign items to expose optional icons and register script items at startup.

### Description

- Implemented dynamic voxel shape computation for `BlockEntitySign` and `BlockEntitySignOnWall` by adding `setCollisionShape`, `setShape` and shared `getFinalShape` logic that composes rotated/moved `VoxelShape`s using `CollisionBoxUtil.cachedRotatedShape` and block `FACING`/transform offsets. 
- Integrated pole handling and per-segment center/left/right pieces into the final shape for freestanding signs, respecting `length`, `unit`, `leftPolePos`, `rightPolePos`, `mtrPoleOffset`, and visibility flags.
- Added optional icon support to script items by extending `JsItem` with an `iconLocation` field and returning it from `getIconLocation`, and updated constructors accordingly.
- Re-enabled JS sign registration in `SignItemFactory` and wired the parsed `icon` property into `JsItem` instances; updated `script_sign.json` to include an `icon` and extended `mtr_sign.json` with an `on_wall` entry.

### Testing

- Built the project with `./gradlew :common:build` which completed successfully.
- Ran the common module tests with `./gradlew :common:test` and they passed.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69f750fd77e0832e8aaaa0f6890e74a6)