### PR TITLE
Add Diaoban drawing framework (Java/JS) and migrate diaoban to use DiaobanDrawManager

### DIFF
--- a/common/src/main/java/com/fangsu/MainClient.java
+++ b/common/src/main/java/com/fangsu/MainClient.java
@@ -9,6 +9,7 @@ import com.fangsu.render.sowcerext.reuse.AtlasManager;
 import com.fangsu.render.sowcerext.reuse.DrawScheduler;
 import com.fangsu.render.sowcerext.reuse.ModelManager;
 import com.fangsu.drawing.sign.SignItemFactory;
+import com.fangsu.drawing.diaoban.DiaobanDrawManager;
 import com.fangsu.train.FunctionalCustomTrains;
 import com.fangsu.ui.ModMenus;
 import com.fangsu.userScripts.ScriptManager;
@@ -60,6 +61,7 @@ public class MainClient {
         ResourceUtil.init(resourceManager);
         CustomItems.getInstance().init();
         SignItemFactory.init();
+        DiaobanDrawManager.preload();
         try {
             MainClient.drawScheduler.reloadShaders(resourceManager);
         } catch (Exception e) {

--- a/common/src/main/java/com/fangsu/blockEntities/BlockEntityDiaoban.java
+++ b/common/src/main/java/com/fangsu/blockEntities/BlockEntityDiaoban.java
@@ -7,9 +7,9 @@ import com.fangsu.customItem.SubModelDispInfo;
 import com.fangsu.customItem.SubModelMethodInfo;
 import com.fangsu.customItem.contents.DiaobanContent;
 import com.fangsu.drawing.diaoban.DiaobanDrawManager;
+import com.fangsu.drawing.diaoban.BaseDiaobanDrawing;
 import com.fangsu.extraConfig.*;
 import com.fangsu.mtr.LocalRoute;
-import com.fangsu.mtr.LocalRouteDetail;
 import com.fangsu.blocks.BaseObjBlock;
 import com.fangsu.render.scripting.util.DynamicModelHolder;
 import com.fangsu.render.sowcer.math.Matrices;
@@ -18,13 +18,9 @@ import com.fangsu.render.sowcerext.model.integration.RawMeshBuilder;
 import com.fangsu.scripting.GraphicsTexture;
 import com.fangsu.scripting.ModelHelper;
 import com.fangsu.ui.RouteSelectionScreen;
-import com.fangsu.userScripts.PidsScriptHolder;
-import com.fangsu.userScripts.ScriptHolderBase;
-import com.fangsu.userScripts.ScriptManager;
 import com.fangsu.utils.*;
 import com.google.gson.JsonElement;
 import com.google.gson.JsonPrimitive;
-import mtr.data.Platform;
 import net.minecraft.core.BlockPos;
 import net.minecraft.core.Direction;
 import net.minecraft.network.chat.Component;
@@ -44,7 +40,6 @@ import net.minecraft.world.phys.shapes.VoxelShape;
 import java.awt.*;
 import java.util.*;
 import java.util.List;
-import java.util.concurrent.CompletableFuture;
 
 import static com.fangsu.blocks.ModBlocks.BLOCK_ENTITY_DIAOBAN;
 
@@ -63,7 +58,7 @@ public class BlockEntityDiaoban extends BaseObjBlockEntity implements IPlatformD
     private String shapeRightSerialized = "";
     private Map<String, JsonElement> userExtraConfigs;
 
-    private volatile ScriptHolderBase scriptHolder;
+    private volatile BaseDiaobanDrawing drawing;
     private int texW, texH;
     private boolean withDoorlight;
     private int doorLightType;
@@ -79,8 +74,6 @@ public class BlockEntityDiaoban extends BaseObjBlockEntity implements IPlatformD
     private boolean drawInit = false;
 
     private List<RouteSelectionScreen.RouteSelectInfo> routes;
-
-    private volatile int scriptLoadToken = 0;
 
     public BlockEntityDiaoban(BlockPos blockPos, BlockState blockState) {
         super(BLOCK_ENTITY_DIAOBAN.get(), blockPos, blockState);
@@ -423,21 +416,14 @@ public class BlockEntityDiaoban extends BaseObjBlockEntity implements IPlatformD
                         "DIAOBAN_" + drawKey + "_" + routes + "_" + arrowDirection,
                         texW, texH, true, false
                 ),
-                gt -> drawFunction(gt, scriptHolder, routes, drawState, arrowDirection, texW, texH)
-        );
-
-        final int thisLoadToken = ++scriptLoadToken;
-        ResourceLocation location = new ResourceLocation(drawScript);
-        CompletableFuture.runAsync(() -> {
-            try {
-                ScriptHolderBase loadedHolder = ScriptManager.getInstance().getOrInitHolder(location, PidsScriptHolder::new);
-                if (loadedHolder != null && thisLoadToken == scriptLoadToken) {
-                    scriptHolder = loadedHolder;
+                gt -> {
+                    BaseDiaobanDrawing drawer = drawing;
+                    if (drawer != null) {
+                        drawer.draw(gt, routes, drawState, arrowDirection, texW, texH);
+                    }
                 }
-            } catch (Throwable e) {
-                Main.LOGGER.error("Failed to load Diaoban script async {}", location, e);
-            }
-        }, ScriptManager.SCRIPT_EXECUTOR);
+        );
+        drawing = DiaobanDrawManager.createDrawing(drawScript);
         drawInit = true;
     }
 

--- a/common/src/main/java/com/fangsu/drawing/diaoban/BaseDiaobanDrawing.java
+++ b/common/src/main/java/com/fangsu/drawing/diaoban/BaseDiaobanDrawing.java
@@ -1,4 +1,22 @@
 package com.fangsu.drawing.diaoban;
 
+import com.fangsu.blockEntities.RouteDrawer;
+import com.fangsu.scripting.GraphicsTexture;
+import com.fangsu.ui.RouteSelectionScreen;
+
+import java.util.List;
+import java.util.Map;
+
 public abstract class BaseDiaobanDrawing {
+    public abstract void draw(GraphicsTexture gt, List<RouteSelectionScreen.RouteSelectInfo> routes,
+                              Map<String, Object> drawState, int arrowDirection, int texW, int texH);
+
+    protected RouteDrawer.RouteDrawInfo buildDrawInfo(List<RouteSelectionScreen.RouteSelectInfo> routes, int arrowDirection, int texW, int texH) {
+        RouteSelectionScreen.RouteSelectInfo info = routes.isEmpty() ? null : routes.get(0);
+        if (info == null || info.route == null) {
+            return new RouteDrawer.RouteDrawInfo(null, arrowDirection, null, 0, new int[]{0, 0, texW, texH});
+        }
+        int index = info.plat != null ? info.route.getPlatformIdIndex(info.plat.id) : 0;
+        return new RouteDrawer.RouteDrawInfo(info.route.asRouteDetail(), arrowDirection, info.plat, index, new int[]{0, 0, texW, texH});
+    }
 }

--- a/common/src/main/java/com/fangsu/drawing/diaoban/DiaobanDrawManager.java
+++ b/common/src/main/java/com/fangsu/drawing/diaoban/DiaobanDrawManager.java
@@ -1,6 +1,7 @@
 package com.fangsu.drawing.diaoban;
 
 import com.fangsu.customItem.ModelSelectInfo;
+import com.fangsu.Main;
 import com.fangsu.utils.ResourceUtil;
 import com.google.gson.JsonArray;
 import com.google.gson.JsonElement;
@@ -8,21 +9,47 @@ import com.google.gson.JsonObject;
 import net.minecraft.resources.ResourceLocation;
 
 import java.util.ArrayList;
+import java.util.Collections;
+import java.util.HashMap;
 import java.util.List;
+import java.util.Map;
+import java.util.function.Supplier;
 
 public final class DiaobanDrawManager {
     private static final ResourceLocation SCRIPTS_LOCATION = new ResourceLocation("fangsu:diaoban/diaoban_scripts.json");
+    private static final String JAVA_DRAW_ROUTE_LIKE = "java:route_like";
+    private static final List<ModelSelectInfo> drawOptions = new ArrayList<>();
+    private static final Map<String, Supplier<BaseDiaobanDrawing>> drawingSuppliers = new HashMap<>();
 
     private DiaobanDrawManager() {
     }
 
-    public static List<ModelSelectInfo> getDrawOptions() {
-        List<ModelSelectInfo> result = new ArrayList<>();
-        injectScriptDrawers(result);
-        return result;
+    public static void preload() {
+        drawOptions.clear();
+        drawingSuppliers.clear();
+
+        registerJavaDrawing("指示牌样式(Java)", JAVA_DRAW_ROUTE_LIKE, "内置 Java 绘制，无需 JS", RouteLikeDiaobanDrawing::new);
+        injectScriptDrawers();
     }
 
-    private static void injectScriptDrawers(List<ModelSelectInfo> out) {
+    public static List<ModelSelectInfo> getDrawOptions() {
+        return Collections.unmodifiableList(drawOptions);
+    }
+
+    public static void registerJavaDrawing(String text, String key, String contentText, Supplier<BaseDiaobanDrawing> factory) {
+        drawOptions.add(new ModelSelectInfo(text, key, contentText));
+        drawingSuppliers.put(key, factory);
+    }
+
+    public static BaseDiaobanDrawing createDrawing(String key) {
+        Supplier<BaseDiaobanDrawing> javaFactory = drawingSuppliers.get(key);
+        if (javaFactory != null) {
+            return javaFactory.get();
+        }
+        return new JsDiaobanDrawing(key);
+    }
+
+    private static void injectScriptDrawers() {
         try {
             JsonObject loaded = ResourceUtil.loadAsJSON(SCRIPTS_LOCATION).getAsJsonObject();
             if (!loaded.has("content")) return;
@@ -33,12 +60,13 @@ public final class DiaobanDrawManager {
                 String text = item.get("text").getAsString();
                 String content = item.get("content").getAsString();
                 if (item.has("contentText")) {
-                    out.add(new ModelSelectInfo(text, content, item.get("contentText").getAsString()));
+                    drawOptions.add(new ModelSelectInfo(text, content, item.get("contentText").getAsString()));
                 } else {
-                    out.add(new ModelSelectInfo(text, content));
+                    drawOptions.add(new ModelSelectInfo(text, content));
                 }
             }
-        } catch (Exception ignored) {
+        } catch (Exception e) {
+            Main.LOGGER.error("Failed to preload diaoban draw scripts", e);
         }
     }
 }

--- a/common/src/main/java/com/fangsu/drawing/diaoban/JsDiaobanDrawing.java
+++ b/common/src/main/java/com/fangsu/drawing/diaoban/JsDiaobanDrawing.java
@@ -1,0 +1,26 @@
+package com.fangsu.drawing.diaoban;
+
+import com.fangsu.scripting.GraphicsTexture;
+import com.fangsu.ui.RouteSelectionScreen;
+import com.fangsu.userScripts.PidsScriptHolder;
+import com.fangsu.userScripts.ScriptHolderBase;
+import com.fangsu.userScripts.ScriptManager;
+import net.minecraft.resources.ResourceLocation;
+
+import java.util.List;
+import java.util.Map;
+
+public class JsDiaobanDrawing extends BaseDiaobanDrawing {
+    private final ScriptHolderBase scriptHolder;
+
+    public JsDiaobanDrawing(String scriptPath) {
+        this.scriptHolder = ScriptManager.getInstance().getOrInitHolder(new ResourceLocation(scriptPath), PidsScriptHolder::new);
+    }
+
+    @Override
+    public void draw(GraphicsTexture gt, List<RouteSelectionScreen.RouteSelectInfo> routes, Map<String, Object> drawState, int arrowDirection, int texW, int texH) {
+        if (scriptHolder == null) return;
+        ScriptManager.getInstance().requestRunFunctionWithCallback(scriptHolder, gt::upload, "draw", gt.graphics, drawState,
+                buildDrawInfo(routes, arrowDirection, texW, texH));
+    }
+}

--- a/common/src/main/java/com/fangsu/drawing/diaoban/RouteLikeDiaobanDrawing.java
+++ b/common/src/main/java/com/fangsu/drawing/diaoban/RouteLikeDiaobanDrawing.java
@@ -1,0 +1,46 @@
+package com.fangsu.drawing.diaoban;
+
+import com.fangsu.blockEntities.RouteDrawer;
+import com.fangsu.scripting.GraphicsTexture;
+import com.fangsu.ui.RouteSelectionScreen;
+
+import java.awt.*;
+import java.util.List;
+import java.util.Map;
+
+public class RouteLikeDiaobanDrawing extends BaseDiaobanDrawing {
+    @Override
+    public void draw(GraphicsTexture gt, List<RouteSelectionScreen.RouteSelectInfo> routes, Map<String, Object> drawState, int arrowDirection, int texW, int texH) {
+        Graphics2D g = gt.graphics;
+        RouteDrawer.RouteDrawInfo drawInfo = buildDrawInfo(routes, arrowDirection, texW, texH);
+        g.setComposite(AlphaComposite.Clear);
+        g.fillRect(0, 0, texW, texH);
+        g.setComposite(AlphaComposite.SrcOver);
+
+        g.setColor(new Color(18, 18, 18, 230));
+        g.fillRoundRect(0, 0, texW, texH, 12, 12);
+
+        final Color routeColor = drawInfo.routeInfo() != null ? drawInfo.routeInfo().routeColor : new Color(0x666666);
+        g.setColor(routeColor);
+        g.fillRect(0, 0, Math.max(3, texW / 20), texH);
+
+        g.setColor(Color.WHITE);
+        g.setFont(new Font("SansSerif", Font.BOLD, Math.max(12, texH / 4)));
+        String routeName = drawInfo.routeInfo() != null ? drawInfo.routeInfo().routeName : "N/A";
+        g.drawString(routeName, Math.max(8, texW / 14), texH / 2);
+
+        g.setFont(new Font("SansSerif", Font.PLAIN, Math.max(10, texH / 6)));
+        String destination = "";
+        if (drawInfo.routeInfo() != null && !drawInfo.routeInfo().drawStations.isEmpty()) {
+            destination = drawInfo.routeInfo().drawStations.get(drawInfo.routeInfo().drawStations.size() - 1).stationName;
+        }
+        g.drawString(destination, Math.max(8, texW / 14), (int) (texH * 0.78f));
+
+        if (drawInfo.arrowDirection() == 1) {
+            g.fillPolygon(new int[]{texW - 26, texW - 12, texW - 26}, new int[]{texH / 2, texH / 2 - 8, texH / 2 + 8}, 3);
+        } else if (drawInfo.arrowDirection() == 2) {
+            g.fillPolygon(new int[]{12, 26, 26}, new int[]{texH / 2, texH / 2 - 8, texH / 2 + 8}, 3);
+        }
+        gt.upload();
+    }
+}


### PR DESCRIPTION
### Motivation
- Provide a pluggable drawing system for diaoban (display board) so drawings can be implemented in Java or JS and selected via configuration.
- Replace per-instance async script holder logic with a centralized manager and drawing abstraction to simplify lifecycle and reduce concurrency complexity.

### Description
- Introduce a drawing abstraction `BaseDiaobanDrawing` with helper `buildDrawInfo` to prepare route drawing data. 
- Add `DiaobanDrawManager` to preload available drawers, register builtin Java drawers, load script-based options from `fangsu:diaoban/diaoban_scripts.json`, and create drawing instances via `createDrawing`.
- Implement `JsDiaobanDrawing` to wrap existing JS script-based drawing using `ScriptManager` and `RouteLikeDiaobanDrawing` as a built-in Java drawer that renders a route-style sign.
- Migrate `BlockEntityDiaoban` to use a `BaseDiaobanDrawing drawing` instead of `ScriptHolderBase scriptHolder`, remove the async script loading/token logic, and invoke `drawing.draw(...)` when uploading graphics.
- Call `DiaobanDrawManager.preload()` from `MainClient.initResources()` so draw options and suppliers are prepared at resource init time, and improve error logging when loading script list.

### Testing
- Ran a full project build with `./gradlew build`, which completed successfully.
- Ran unit tests with `./gradlew test`, and the test suite passed successfully.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a0058d4e578832e92a3aa26fe453f50)