### PR TITLE
Align G2dTextHelper.drawStrMultiLines y-baseline with drawStrUnified and update call sites

### DIFF
--- a/common/src/main/java/com/fangsu/drawing/sign/DestinationItem.java
+++ b/common/src/main/java/com/fangsu/drawing/sign/DestinationItem.java
@@ -57,7 +57,7 @@ public class DestinationItem extends SignItem {
         Graphics2D g = ctx.graphics();
         float u = ctx.unit();
         g.setColor(Color.WHITE);
-        G2dTextHelper.drawStrMultiLines(g, font, (int) ctx.x(), (int) ctx.y(), (int) u, align, lines);
+        G2dTextHelper.drawStrMultiLines(g, font, (int) ctx.x(), (int) ctx.y() - (int) u, (int) u, align, lines);
     }
 
     @Override

--- a/common/src/main/java/com/fangsu/drawing/sign/RouteItemA.java
+++ b/common/src/main/java/com/fangsu/drawing/sign/RouteItemA.java
@@ -76,9 +76,9 @@ public class RouteItemA extends SignItem {
             int currentX = x + (int) (u * 0.1f);
             String name = RouteNameUtil.getCJKLineName(TextUtil.getCjkParts(routeName));
             currentX += G2dTextHelper.drawStrUnified(g, font, name, currentX, (int) (y + u * 0.7f), u * 0.75f, 0);
-            currentX += G2dTextHelper.drawStrMultiLines(g, font, currentX, y + (int) (u * 0.1f), (int) (u * 0.65f), 0, "号线", TextUtil.getNonCjkParts(routeName));
+            currentX += G2dTextHelper.drawStrMultiLines(g, font, currentX, y + (int) (u * 0.1f) - (int) (u * 0.65f), (int) (u * 0.65f), 0, "号线", TextUtil.getNonCjkParts(routeName));
         } else {
-            G2dTextHelper.drawStrMultiLines(g, font, (int) (x + u * 0.1f), y + (int) (u * 0.075f), (int) (u * 0.7f), 1, TextUtil.getNonExtraParts(routeName).split("\\|"));
+            G2dTextHelper.drawStrMultiLines(g, font, (int) (x + u * 0.1f), y + (int) (u * 0.075f) - (int) (u * 0.7f), (int) (u * 0.7f), 1, TextUtil.getNonExtraParts(routeName).split("\\|"));
         }
     }
 

--- a/common/src/main/java/com/fangsu/drawing/sign/RouteItemB.java
+++ b/common/src/main/java/com/fangsu/drawing/sign/RouteItemB.java
@@ -77,9 +77,9 @@ public class RouteItemB extends SignItem {
             int currentX = x + (int) (u * 0.25f);
             String name = RouteNameUtil.getCJKLineName(TextUtil.getCjkParts(routeName));
             currentX += G2dTextHelper.drawStrUnified(g, font, name, currentX, (int) (y + u * 0.8f), u * 0.8f, 0);
-            currentX += G2dTextHelper.drawStrMultiLines(g, font, currentX, y + (int) (u * 0.15f), (int) (u * 0.75f), 0, "号线", TextUtil.getNonCjkParts(routeName));
+            currentX += G2dTextHelper.drawStrMultiLines(g, font, currentX, y + (int) (u * 0.15f) - (int) (u * 0.75f), (int) (u * 0.75f), 0, "号线", TextUtil.getNonCjkParts(routeName));
         } else {
-            G2dTextHelper.drawStrMultiLines(g, font, (int) (x + u * 0.25f), y + (int) (u * 0.125f), (int) (u * 0.8f), 1, TextUtil.getNonExtraParts(routeName).split("\\|"));
+            G2dTextHelper.drawStrMultiLines(g, font, (int) (x + u * 0.25f), y + (int) (u * 0.125f) - (int) (u * 0.8f), (int) (u * 0.8f), 1, TextUtil.getNonExtraParts(routeName).split("\\|"));
         }
     }
 

--- a/common/src/main/java/com/fangsu/drawing/sign/TextItem.java
+++ b/common/src/main/java/com/fangsu/drawing/sign/TextItem.java
@@ -66,7 +66,7 @@ public class TextItem extends SignItem {
         g.setColor(color);
         Font font;
         font = ResourceUtil.loadFont(fontLocation);
-        G2dTextHelper.drawStrMultiLines(g, font, (int) ctx.x(), (int) ctx.y(), (int) u, align, lines);
+        G2dTextHelper.drawStrMultiLines(g, font, (int) ctx.x(), (int) ctx.y() - (int) u, (int) u, align, lines);
     }
 
     @Override

--- a/common/src/main/java/com/fangsu/scripting/G2dTextHelper.java
+++ b/common/src/main/java/com/fangsu/scripting/G2dTextHelper.java
@@ -29,7 +29,7 @@ public class G2dTextHelper {
     public static int drawStrMultiLines(Graphics2D g, Font cjkFont, Font nonCjkFont, int x, int y, int h, int align, String... lines) {
         if (lines.length == 0) return 0;
         int width = getMultiLinesWidth(g, cjkFont, nonCjkFont, h, lines);
-        int currentY = (int) (y - h * (0.095));
+        int currentY = (int) (y + h - h * (0.095));
         for (int i = 0; i < lines.length; i++) {
             String line = lines[i];
             int fontSize = (int) (h * ACTUAL_DRAW_HEIGHT / (lines.length + 2) * (i == 0 ? 3 : 1));

--- a/common/src/main/java/com/fangsu/scripting/JsFunctions.java
+++ b/common/src/main/java/com/fangsu/scripting/JsFunctions.java
@@ -128,7 +128,7 @@ public class JsFunctions {
     public static int jsDrawStrDl(Graphics2D g, Font cjkFont, Font nonCjkFont, String str, double x, double y, double h, int bd, int d) {
         String drawStr = str == null ? "" : str;
         int width = G2dTextHelper.getMultiLinesWidth(g, cjkFont, nonCjkFont, (float) h, drawStr.split("\\|"));
-        return G2dTextHelper.drawStrMultiLines(g, cjkFont, nonCjkFont, (int) x - (bd == 1 ? width / 2 : bd == 2 ? width : 0), (int) y, (int) h, d, drawStr.split("\\|"));
+        return G2dTextHelper.drawStrMultiLines(g, cjkFont, nonCjkFont, (int) x - (bd == 1 ? width / 2 : bd == 2 ? width : 0), (int) y - (int) h, (int) h, d, drawStr.split("\\|"));
     }
 
     public static int jsGetDLStringWidth(Graphics2D g, Font cjkFont, Font nonCjkFont, String str, double h) {

--- a/common/src/main/java/com/fangsu/train/lcds/MtrLcd.java
+++ b/common/src/main/java/com/fangsu/train/lcds/MtrLcd.java
@@ -148,7 +148,7 @@ public class MtrLcd extends LcdBase {
                     g.fillRoundRect(currentX - lineSize / 2, centralY - interchangeHeight, lineSize, interchangeHeight, lineSize, lineSize);
                     g.setColor(isInRoute ? Color.BLACK : passedColor);
                     int textWidth = G2dTextHelper.getMultiLinesWidth(g, cjkFont, nonCjkFont, stationSize, thisTrans.routeName.split("\\|"));
-                    G2dTextHelper.drawStrMultiLines(g, cjkFont, nonCjkFont, currentX - textWidth / 2, centralY - interchangeHeight - stationSize - lineSize / 5, stationSize, 1, thisTrans.routeName.split("\\|"));
+                    G2dTextHelper.drawStrMultiLines(g, cjkFont, nonCjkFont, currentX - textWidth / 2, centralY - interchangeHeight - stationSize - lineSize / 5 - stationSize, stationSize, 1, thisTrans.routeName.split("\\|"));
                 } else {
                     for (int j = 0; j < station.transInfo.size(); j++) {
                         ColorNameTuple thisTrans = station.transInfo.get(j);
@@ -156,7 +156,7 @@ public class MtrLcd extends LcdBase {
                         g.setColor(isInRoute ? thisTrans.routeColor : passedColor);
                         g.fillRoundRect(currentX, currentY, interchangeWidth, lineSize, lineSize, lineSize);
                         g.setColor(isInRoute ? Color.BLACK : passedColor);
-                        G2dTextHelper.drawStrMultiLines(g, cjkFont, nonCjkFont, currentX + interchangeWidth, currentY, lineSize, 0, thisTrans.routeName.split("\\|"));
+                        G2dTextHelper.drawStrMultiLines(g, cjkFont, nonCjkFont, currentX + interchangeWidth, currentY - lineSize, lineSize, 0, thisTrans.routeName.split("\\|"));
                     }
                     int stationHeight = (int) (lineSize * 0.5 + lineSize * 1.5 * station.transInfo.size());
                     g.setColor(!isInRoute ? passedColor : routeColor);
@@ -173,7 +173,7 @@ public class MtrLcd extends LcdBase {
             }
             g.setColor(hasPassed || !isInRoute ? passedColor : Color.BLACK);
             int stationNameWidth = G2dTextHelper.getMultiLinesWidth(g, cjkFont, nonCjkFont, lineSize * 2, station.stationName.split("\\|"));
-            G2dTextHelper.drawStrMultiLines(g, cjkFont, nonCjkFont, currentX - stationNameWidth / 2, (int) (centralY + lineSize * 2.5), lineSize * 2, 1, station.stationName.split("\\|"));
+            G2dTextHelper.drawStrMultiLines(g, cjkFont, nonCjkFont, currentX - stationNameWidth / 2, (int) (centralY + lineSize * 2.5) - lineSize * 2, lineSize * 2, 1, station.stationName.split("\\|"));
         }
 
         //draw route name
@@ -196,7 +196,7 @@ public class MtrLcd extends LcdBase {
         currentX += routeNameColorWidth;
         currentX += routeNameBlank;
         g.setColor(Color.BLACK);
-        G2dTextHelper.drawStrMultiLines(g, cjkFont, nonCjkFont, currentX, centralY - routeNameTextHeight / 2, routeNameTextHeight, 0, routeName.split("\\|"));
+        G2dTextHelper.drawStrMultiLines(g, cjkFont, nonCjkFont, currentX, centralY - routeNameTextHeight / 2 - routeNameTextHeight, routeNameTextHeight, 0, routeName.split("\\|"));
 
     }
 
@@ -216,7 +216,7 @@ public class MtrLcd extends LcdBase {
             g.fillRoundRect(currentX, y + h / 20, textWidth + blankWidth * 2, doorOpenHeight, doorOpenHeight, doorOpenHeight);
         }
         g.setColor(Color.BLACK);
-        G2dTextHelper.drawStrMultiLines(g, cjkFont, nonCjkFont, currentX + blankWidth, y + h / 20 + (doorOpenHeight - textHeight) / 2, textHeight, 1, cjkText, nonCjkText);
+        G2dTextHelper.drawStrMultiLines(g, cjkFont, nonCjkFont, currentX + blankWidth, y + h / 20 + (doorOpenHeight - textHeight) / 2 - textHeight, textHeight, 1, cjkText, nonCjkText);
     }
 
     private void drawStationNameCenter(Graphics2D g, int x, int y, int w, int h, String cjkName, String nonCjkName, Font cjkFont, Font nonCjkFont) {


### PR DESCRIPTION
### Motivation
- Make `drawStrMultiLines` use the same y-baseline semantics as `drawStrUnified` so text positioning is consistent across single-line and multi-line drawing helpers.

### Description
- Adjusted `G2dTextHelper.drawStrMultiLines` to initialize `currentY` from `y + h` (changed to `int currentY = (int) (y + h - h * (0.095));`).
- Updated the JS bridge `jsDrawStrDl` in `JsFunctions` to call `drawStrMultiLines` with `y - h` so script callers keep previous visual placement (`(int) y - (int) h`).
- Updated Java call sites to pass the adjusted y (subtracting the height) so rendered output remains visually close to the original, including changes in `RouteItemA`, `RouteItemB`, `TextItem`, `DestinationItem`, and `MtrLcd`.

### Testing
- Attempted to compile with `./gradlew :common:compileJava -q`, but the build did not complete in this environment due to a Gradle/JDK incompatibility error (`Unsupported class file major version 69`).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a0862cbcc64832e95f024e13cf4bd6f)