### PR TITLE
Fix multi-version compile issues (widget APIs, Button ctor, registries, renders)

### DIFF
--- a/common/src/main/java/com/fangsu/blockEntities/client/BaseBlockEntityRender.java
+++ b/common/src/main/java/com/fangsu/blockEntities/client/BaseBlockEntityRender.java
@@ -20,7 +20,7 @@ import net.minecraft.client.renderer.blockentity.BlockEntityRenderDispatcher;
 import net.minecraft.client.renderer.blockentity.BlockEntityRenderer;
 import net.minecraft.core.BlockPos;
 import net.minecraft.core.Direction;
-//#if MC_VERSION >= 12000
+//#if MC_VERSION >= 11904
 import net.minecraft.world.item.ItemDisplayContext;
 //#endif
 import net.minecraft.world.item.ItemStack;
@@ -67,6 +67,8 @@ public class BaseBlockEntityRender<T extends BaseObjBlockEntity> implements Bloc
             PoseStackUtil.rotY(matrices, (float) ((System.currentTimeMillis() % 1000) * (Math.PI * 2 / 1000)));
             //#if MC_VERSION >= 12000
             Minecraft.getInstance().getItemRenderer().renderStatic(BARRIER_ITEM_STACK.get(), ItemDisplayContext.GROUND, lightToUse, 0, matrices, multiBufferSource, world, 0);
+            //#elseif MC_VERSION >= 11904
+            //$$ Minecraft.getInstance().getItemRenderer().renderStatic(BARRIER_ITEM_STACK.get(), ItemDisplayContext.GROUND, lightToUse, 0, matrices, multiBufferSource, 0);
             //#else
             //$$ Minecraft.getInstance().getItemRenderer().renderStatic(BARRIER_ITEM_STACK.get(), net.minecraft.client.renderer.block.model.ItemTransforms.TransformType.GROUND, lightToUse, 0, matrices, multiBufferSource, 0);
             //#endif

--- a/common/src/main/java/com/fangsu/blocks/BlockScreendoor.java
+++ b/common/src/main/java/com/fangsu/blocks/BlockScreendoor.java
@@ -29,7 +29,6 @@ public class BlockScreendoor extends BaseObjBlock implements IBlockPlatform {
         return new BlockEntityScreendoor(pos, state);
     }
 
-    @Override
     public void tick(
             @NotNull BlockState state,
             @NotNull ServerLevel level,

--- a/common/src/main/java/com/fangsu/blocks/BlockScreendoorGlass.java
+++ b/common/src/main/java/com/fangsu/blocks/BlockScreendoorGlass.java
@@ -29,7 +29,6 @@ public class BlockScreendoorGlass extends BaseObjBlock implements IBlockPlatform
         return new BlockEntityScreendoorGlass(pos, state);
     }
 
-    @Override
     public void tick(
             @NotNull BlockState state,
             @NotNull ServerLevel level,

--- a/common/src/main/java/com/fangsu/extraConfig/AbstractMultiLineEditBox.java
+++ b/common/src/main/java/com/fangsu/extraConfig/AbstractMultiLineEditBox.java
@@ -1,4 +1,4 @@
-﻿package com.fangsu.extraConfig;
+package com.fangsu.extraConfig;
 
 import net.minecraft.client.Minecraft;
 import net.minecraft.client.gui.Font;
@@ -60,17 +60,23 @@ public abstract class AbstractMultiLineEditBox extends AbstractWidget {
         graphics.fill(getX(), getY(), getX() + width, getY() + height, 0xFF000000);
         graphics.drawString(font, value, getX() + 4, getY() + (height - 8) / 2, 0xFFFFFF, false);
     }
-    //#elseif MC_VERSION >= 11903
+    //#elseif MC_VERSION >= 11904
     //$$@Override
     //$$public void renderWidget(com.mojang.blaze3d.vertex.PoseStack poseStack, int mouseX, int mouseY, float partialTick) {
+    //$$    net.minecraft.client.gui.Gui.fill(poseStack, getX(), getY(), getX() + width, getY() + height, 0xFF000000);
+    //$$    font.draw(poseStack, value, getX() + 4, getY() + (height - 8) / 2, 0xFFFFFF);
+    //$$}
+    //#elseif MC_VERSION >= 11903
+    //$$@Override
+    //$$public void renderButton(com.mojang.blaze3d.vertex.PoseStack poseStack, int mouseX, int mouseY, float partialTick) {
     //$$    net.minecraft.client.gui.Gui.fill(poseStack, getX(), getY(), getX() + width, getY() + height, 0xFF000000);
     //$$    font.draw(poseStack, value, getX() + 4, getY() + (height - 8) / 2, 0xFFFFFF);
     //$$}
     //#else
     //$$@Override
     //$$public void render(com.mojang.blaze3d.vertex.PoseStack poseStack, int mouseX, int mouseY, float partialTick) {
-    //$$    net.minecraft.client.gui.Gui.fill(poseStack, getX(), getY(), getX() + width, getY() + height, 0xFF000000);
-    //$$    font.draw(poseStack, value, getX() + 4, getY() + (height - 8) / 2, 0xFFFFFF);
+    //$$    net.minecraft.client.gui.Gui.fill(poseStack, this.x, this.y, this.x + width, this.y + height, 0xFF000000);
+    //$$    font.draw(poseStack, value, this.x + 4, this.y + (height - 8) / 2, 0xFFFFFF);
     //$$}
     //#endif
 

--- a/common/src/main/java/com/fangsu/extraConfig/CompoundWidget.java
+++ b/common/src/main/java/com/fangsu/extraConfig/CompoundWidget.java
@@ -1,4 +1,4 @@
-﻿package com.fangsu.extraConfig;
+package com.fangsu.extraConfig;
 
 import com.fangsu.mappings.ComponentHelper;
 //#if MC_VERSION >= 12000
@@ -33,9 +33,18 @@ public class CompoundWidget extends AbstractWidget {
             }
         }
     }
-    //#elseif MC_VERSION >= 11903
+    //#elseif MC_VERSION >= 11904
     //$$@Override
     //$$public void renderWidget(com.mojang.blaze3d.vertex.PoseStack poseStack, int mouseX, int mouseY, float partial) {
+    //$$    for (AbstractWidget w : children) {
+    //$$        if (w.visible) {
+    //$$            w.render(poseStack, mouseX, mouseY, partial);
+    //$$        }
+    //$$    }
+    //$$}
+    //#elseif MC_VERSION >= 11903
+    //$$@Override
+    //$$public void renderButton(com.mojang.blaze3d.vertex.PoseStack poseStack, int mouseX, int mouseY, float partial) {
     //$$    for (AbstractWidget w : children) {
     //$$        if (w.visible) {
     //$$            w.render(poseStack, mouseX, mouseY, partial);

--- a/common/src/main/java/com/fangsu/extraConfig/ConfigRow.java
+++ b/common/src/main/java/com/fangsu/extraConfig/ConfigRow.java
@@ -1,4 +1,4 @@
-﻿package com.fangsu.extraConfig;
+package com.fangsu.extraConfig;
 
 //#if MC_VERSION >= 12000
 import net.minecraft.client.gui.GuiGraphics;
@@ -26,16 +26,22 @@ public class ConfigRow extends AbstractWidget {
         g.drawString(net.minecraft.client.Minecraft.getInstance().font, getMessage(), getX(), getY() + (height - 8) / 2, 0xFFFFFF);
         field.render(g, mouseX, mouseY, partial);
     }
-    //#elseif MC_VERSION >= 11903
+    //#elseif MC_VERSION >= 11904
     //$$@Override
     //$$public void renderWidget(com.mojang.blaze3d.vertex.PoseStack poseStack, int mouseX, int mouseY, float partial) {
+    //$$    net.minecraft.client.Minecraft.getInstance().font.draw(poseStack, getMessage(), (float) getX(), (float) (getY() + (height - 8) / 2), 0xFFFFFF);
+    //$$    field.render(poseStack, mouseX, mouseY, partial);
+    //$$}
+    //#elseif MC_VERSION >= 11903
+    //$$@Override
+    //$$public void renderButton(com.mojang.blaze3d.vertex.PoseStack poseStack, int mouseX, int mouseY, float partial) {
     //$$    net.minecraft.client.Minecraft.getInstance().font.draw(poseStack, getMessage(), (float) getX(), (float) (getY() + (height - 8) / 2), 0xFFFFFF);
     //$$    field.render(poseStack, mouseX, mouseY, partial);
     //$$}
     //#else
     //$$@Override
     //$$public void render(com.mojang.blaze3d.vertex.PoseStack poseStack, int mouseX, int mouseY, float partial) {
-    //$$    net.minecraft.client.Minecraft.getInstance().font.draw(poseStack, getMessage(), (float) getX(), (float) (getY() + (height - 8) / 2), 0xFFFFFF);
+    //$$    net.minecraft.client.Minecraft.getInstance().font.draw(poseStack, getMessage(), (float) this.x, (float) (this.y + (height - 8) / 2), 0xFFFFFF);
     //$$    field.render(poseStack, mouseX, mouseY, partial);
     //$$}
     //#endif

--- a/common/src/main/java/com/fangsu/extraConfig/ConfigWidget.java
+++ b/common/src/main/java/com/fangsu/extraConfig/ConfigWidget.java
@@ -81,7 +81,7 @@ public class ConfigWidget extends AbstractWidget {
 
     //#if MC_VERSION >= 12000
     @Override
-    protected void renderWidget(net.minecraft.client.gui.GuiGraphics gui, int mouseX, int mouseY, float partialTick) {
+    public void renderWidget(net.minecraft.client.gui.GuiGraphics gui, int mouseX, int mouseY, float partialTick) {
         var font = net.minecraft.client.Minecraft.getInstance().font;
         int maxWidth = Math.max(0, labelWidth - 4);
         String label = maxWidth > 0
@@ -93,9 +93,23 @@ public class ConfigWidget extends AbstractWidget {
             w.render(gui, mouseX, mouseY, partialTick);
         }
     }
+    //#elseif MC_VERSION >= 11904
+    //$$@Override
+    //$$public void renderWidget(com.mojang.blaze3d.vertex.PoseStack poseStack, int mouseX, int mouseY, float partialTick) {
+    //$$    var font = net.minecraft.client.Minecraft.getInstance().font;
+    //$$    int maxWidth = Math.max(0, labelWidth - 4);
+    //$$    String label = maxWidth > 0
+    //$$            ? font.plainSubstrByWidth(getMessage().getString(), maxWidth)
+    //$$            : getMessage().getString();
+    //$$    int textY = getY() + (height - 8) / 2;
+    //$$    font.draw(poseStack, label, (float) getX(), (float) textY, 0x202020);
+    //$$    for (AbstractWidget w : children) {
+    //$$        w.render(poseStack, mouseX, mouseY, partialTick);
+    //$$    }
+    //$$}
     //#elseif MC_VERSION >= 11903
     //$$@Override
-    //$$protected void renderWidget(com.mojang.blaze3d.vertex.PoseStack poseStack, int mouseX, int mouseY, float partialTick) {
+    //$$public void renderButton(com.mojang.blaze3d.vertex.PoseStack poseStack, int mouseX, int mouseY, float partialTick) {
     //$$    var font = net.minecraft.client.Minecraft.getInstance().font;
     //$$    int maxWidth = Math.max(0, labelWidth - 4);
     //$$    String label = maxWidth > 0
@@ -115,8 +129,8 @@ public class ConfigWidget extends AbstractWidget {
     //$$    String label = maxWidth > 0
     //$$            ? font.plainSubstrByWidth(getMessage().getString(), maxWidth)
     //$$            : getMessage().getString();
-    //$$    int textY = getY() + (height - 8) / 2;
-    //$$    font.draw(poseStack, label, (float) getX(), (float) textY, 0x202020);
+    //$$    int textY = this.y + (height - 8) / 2;
+    //$$    font.draw(poseStack, label, (float) this.x, (float) textY, 0x202020);
     //$$    for (AbstractWidget w : children) {
     //$$        w.render(poseStack, mouseX, mouseY, partialTick);
     //$$    }

--- a/common/src/main/java/com/fangsu/extraConfig/SliderWidget.java
+++ b/common/src/main/java/com/fangsu/extraConfig/SliderWidget.java
@@ -1,4 +1,4 @@
-﻿package com.fangsu.extraConfig;
+package com.fangsu.extraConfig;
 
 import com.fangsu.mappings.ComponentHelper;
 import net.minecraft.client.Minecraft;
@@ -85,9 +85,14 @@ public class SliderWidget extends AbstractWidget {
     public void renderWidget(GuiGraphics g, int mouseX, int mouseY, float partial) {
         slider.render(g, mouseX, mouseY, partial);
     }
-    //#elseif MC_VERSION >= 11903
+    //#elseif MC_VERSION >= 11904
     //$$@Override
     //$$public void renderWidget(com.mojang.blaze3d.vertex.PoseStack poseStack, int mouseX, int mouseY, float partial) {
+    //$$    slider.render(poseStack, mouseX, mouseY, partial);
+    //$$}
+    //#elseif MC_VERSION >= 11903
+    //$$@Override
+    //$$public void renderButton(com.mojang.blaze3d.vertex.PoseStack poseStack, int mouseX, int mouseY, float partial) {
     //$$    slider.render(poseStack, mouseX, mouseY, partial);
     //$$}
     //#else
@@ -107,7 +112,7 @@ public class SliderWidget extends AbstractWidget {
         return slider.mouseDragged(x, y, btn, dx, dy);
     }
 
-    //#if MC_VERSION >= 12000
+    //#if MC_VERSION >= 11903
     @Override
     protected void updateWidgetNarration(NarrationElementOutput narration) {
     }
@@ -182,7 +187,7 @@ public class SliderWidget extends AbstractWidget {
             if (!this.visible || button != 0) {
                 return false;
             }
-            //#if MC_VERSION >= 12000
+            //#if MC_VERSION >= 11903
             if (mouseX < this.getX() || mouseX > this.getX() + this.width
                     || mouseY < this.getY() || mouseY > this.getY() + this.height) {
                 return false;

--- a/common/src/main/java/com/fangsu/mappings/FangSuRegistries.java
+++ b/common/src/main/java/com/fangsu/mappings/FangSuRegistries.java
@@ -26,6 +26,7 @@ public class FangSuRegistries {
     public static final ResourceLocation ITEM_KEY = net.minecraft.core.registries.Registries.ITEM.location();
     public static final ResourceLocation BLOCK_ENTITY_TYPE_KEY = net.minecraft.core.registries.Registries.BLOCK_ENTITY_TYPE.location();
     public static final ResourceLocation MENU_KEY = net.minecraft.core.registries.Registries.MENU.location();
+    public static final ResourceLocation CREATIVE_MODE_TAB_KEY = net.minecraft.core.registries.Registries.CREATIVE_MODE_TAB.location();
     //#else
     //$$public static final ResourceLocation BLOCK_KEY = new ResourceLocation("minecraft:block");
     //$$public static final ResourceLocation ITEM_KEY = new ResourceLocation("minecraft:item");
@@ -61,4 +62,10 @@ public class FangSuRegistries {
     public static DeferredRegister<MenuType<?>> createMenuRegister(String modId) {
         return createDeferredRegister(modId, MENU_KEY);
     }
+
+    //#if MC_VERSION >= 11903
+    public static DeferredRegister<CreativeModeTab> createCreativeTabRegister(String modId) {
+        return createDeferredRegister(modId, CREATIVE_MODE_TAB_KEY);
+    }
+    //#endif
 }

--- a/common/src/main/java/com/fangsu/mixin/LiftCustomizationScreenMixin.java
+++ b/common/src/main/java/com/fangsu/mixin/LiftCustomizationScreenMixin.java
@@ -42,7 +42,7 @@ public class LiftCustomizationScreenMixin {
 
     @Inject(method = "<init>", at = @At("TAIL"), remap = false)
     private void onInit(LiftClient lift, CallbackInfo ci) {
-        //#if MC_VERSION >= 12000
+        //#if MC_VERSION >= 11903
         fangsu$buttonModel = Button.builder(
                 ComponentHelper.translatable("ui.fangsu.block.modelSelect"),
                 button -> {

--- a/common/src/main/java/com/fangsu/network/ModNetwork.java
+++ b/common/src/main/java/com/fangsu/network/ModNetwork.java
@@ -7,8 +7,10 @@ import com.fangsu.blockEntities.Syncable;
 import com.fangsu.items.TicketItem;
 import dev.architectury.networking.NetworkManager;
 import net.minecraft.core.BlockPos;
-//#if MC_VERSION >= 12000
+//#if MC_VERSION >= 11903
 import net.minecraft.core.registries.BuiltInRegistries;
+//#endif
+//#if MC_VERSION >= 12000
 import net.minecraft.core.registries.Registries;
 //#endif
 import net.minecraft.network.FriendlyByteBuf;

--- a/common/src/main/java/com/fangsu/ui/BasicConfigScreen.java
+++ b/common/src/main/java/com/fangsu/ui/BasicConfigScreen.java
@@ -1,4 +1,4 @@
-﻿package com.fangsu.ui;
+package com.fangsu.ui;
 
 import com.fangsu.extraConfig.ConfigRow;
 import com.fangsu.extraConfig.ConfigWidget;
@@ -353,40 +353,47 @@ public abstract class BasicConfigScreen extends Screen {
         //#if MC_VERSION >= 12000
         @Override
         public void renderWidget(GuiGraphics graphics, int mouseX, int mouseY, float partialTick) {
-            var g = GraphicContext.of(graphics);
-            var font = Minecraft.getInstance().font;
-            int drawX = this.getX();
-            int textWidth = font.width(text.getString());
-            switch (align) {
-                case CENTER -> drawX = this.getX() - textWidth / 2;
-                case RIGHT -> drawX = this.getX() - textWidth;
-                case LEFT -> drawX = this.getX();
-            }
-            if (bold) {
-                g.drawString(font, text.copy().withStyle(style -> style.withBold(true)), drawX, this.getY(), color, false);
-            } else {
-                g.drawString(font, text, drawX, this.getY(), color, false);
-            }
+            renderLabel(GraphicContext.of(graphics));
         }
+        //#elseif MC_VERSION >= 11904
+        //$$ @Override
+        //$$ public void renderWidget(com.mojang.blaze3d.vertex.PoseStack poseStack, int mouseX, int mouseY, float partialTick) {
+        //$$     renderLabel(GraphicContext.of(poseStack));
+        //$$ }
+        //#elseif MC_VERSION >= 11903
+        //$$ @Override
+        //$$ public void renderButton(com.mojang.blaze3d.vertex.PoseStack poseStack, int mouseX, int mouseY, float partialTick) {
+        //$$     renderLabel(GraphicContext.of(poseStack));
+        //$$ }
         //#else
         //$$ @Override
         //$$ public void render(com.mojang.blaze3d.vertex.PoseStack poseStack, int mouseX, int mouseY, float partialTick) {
-        //$$     var g = GraphicContext.of(poseStack);
-        //$$     var font = Minecraft.getInstance().font;
-        //$$     int drawX = this.getX();
-        //$$     int textWidth = font.width(text.getString());
-        //$$     switch (align) {
-        //$$         case CENTER -> drawX = this.getX() - textWidth / 2;
-        //$$         case RIGHT -> drawX = this.getX() - textWidth;
-        //$$         case LEFT -> drawX = this.getX();
-        //$$     }
-        //$$     if (bold) {
-        //$$         g.drawString(font, text.copy().withStyle(style -> style.withBold(true)), drawX, this.getY(), color, false);
-        //$$     } else {
-        //$$         g.drawString(font, text, drawX, this.getY(), color, false);
-        //$$     }
+        //$$     renderLabel(GraphicContext.of(poseStack));
         //$$ }
         //#endif
+
+        private void renderLabel(GraphicContext g) {
+            var font = Minecraft.getInstance().font;
+            //#if MC_VERSION >= 11903
+            int x = this.getX();
+            int y = this.getY();
+            //#else
+            //$$ int x = this.x;
+            //$$ int y = this.y;
+            //#endif
+            int drawX = x;
+            int textWidth = font.width(text.getString());
+            switch (align) {
+                case CENTER -> drawX = x - textWidth / 2;
+                case RIGHT -> drawX = x - textWidth;
+                case LEFT -> drawX = x;
+            }
+            if (bold) {
+                g.drawString(font, text.copy().withStyle(style -> style.withBold(true)), drawX, y, color, false);
+            } else {
+                g.drawString(font, text, drawX, y, color, false);
+            }
+        }
 
         //#if MC_VERSION >= 11903
         @Override

--- a/common/src/main/java/com/fangsu/ui/ObjBlockConfigScreen.java
+++ b/common/src/main/java/com/fangsu/ui/ObjBlockConfigScreen.java
@@ -1,4 +1,4 @@
-﻿package com.fangsu.ui;
+package com.fangsu.ui;
 
 import com.fangsu.blockEntities.BaseObjBlockEntity;
 import com.fangsu.customItem.CustomItems;
@@ -56,7 +56,7 @@ public class ObjBlockConfigScreen extends BasicConfigScreen {
         int left = getPanelLeft();
         int btnWidth = getPanelWidth();
 
-        //#if MC_VERSION >= 12000
+        //#if MC_VERSION >= 11903
         Button toggleInputButton = Button.builder(getInputToggleLabel(), btn -> {
             useSliderInput = !useSliderInput;
             requestRebuild();

--- a/common/src/main/java/com/fangsu/ui/ScreendoorCentralControlScreen.java
+++ b/common/src/main/java/com/fangsu/ui/ScreendoorCentralControlScreen.java
@@ -1,4 +1,4 @@
-﻿package com.fangsu.ui;
+package com.fangsu.ui;
 
 import com.fangsu.blockEntities.BlockEntityScreendoorCentralControl;
 import com.fangsu.mappings.ComponentHelper;
@@ -62,7 +62,7 @@ public class ScreendoorCentralControlScreen extends Screen {
 
         // ===== 闂ㄩ殧锟?=====
         y += 10;
-        //#if MC_VERSION >= 12000
+        //#if MC_VERSION >= 11903
         isolationBtn = Button.builder(getIsolationLabel(), btn -> {
             isolation = !isolation;
             btn.setMessage(getIsolationLabel());
@@ -75,7 +75,7 @@ public class ScreendoorCentralControlScreen extends Screen {
 
         // ===== 闂ㄥ紑鍚紙浠呭湪闅旂鎵撳紑鏃跺彲鐢級 =====
         y += 25;
-        //#if MC_VERSION >= 12000
+        //#if MC_VERSION >= 11903
         doorOpenBtn = Button.builder(getDoorOpenLabel(), btn -> {
             doorOpen = !doorOpen;
             btn.setMessage(getDoorOpenLabel());
@@ -99,7 +99,7 @@ public class ScreendoorCentralControlScreen extends Screen {
         }
 
         // ===== 娣诲姞鍧愭爣鎸夐挳 =====
-        //#if MC_VERSION >= 12000
+        //#if MC_VERSION >= 11903
         addPosBtn = Button.builder(ComponentHelper.translatable("ui.fangsu.screendoor.centralControl.addPos"), btn -> {
             startPositions.add(BlockPos.ZERO); /*#if MC_VERSION >= 11900*/
             rebuildWidgets(); /*#endif*/
@@ -110,7 +110,7 @@ public class ScreendoorCentralControlScreen extends Screen {
         addRenderableWidget(addPosBtn);
 
         // ===== 閲嶆柊鎵弿鎸夐挳 =====
-        //#if MC_VERSION >= 12000
+        //#if MC_VERSION >= 11903
         scanBtn = Button.builder(ComponentHelper.translatable("ui.fangsu.screendoor.centralControl.scan"), btn -> {
             syncPositionsFromRows();
             ctrl.getStartPositions().clear();
@@ -125,7 +125,7 @@ public class ScreendoorCentralControlScreen extends Screen {
 
         // ===== 淇濆瓨骞堕€€锟?=====
         y += 30;
-        //#if MC_VERSION >= 12000
+        //#if MC_VERSION >= 11903
         saveBtn = Button.builder(ComponentHelper.translatable("ui.fangsu.block.close_and_save"), btn -> {
             saveAndClose();
         }).bounds(panelLeft, y, PANEL_WIDTH, 20).build();
@@ -257,7 +257,7 @@ public class ScreendoorCentralControlScreen extends Screen {
             zBox.setValue(String.valueOf(pos.getZ()));
             addRenderableWidget(zBox);
 
-            //#if MC_VERSION >= 12000
+            //#if MC_VERSION >= 11903
             removeBtn = Button.builder(Component.literal("X"), btn -> {
                 startPositions.remove(pos);
                 /*#if MC_VERSION >= 11900*/ rebuildWidgets(); /*#endif*/

--- a/common/src/main/java/com/fangsu/utils/RegisterUtil.java
+++ b/common/src/main/java/com/fangsu/utils/RegisterUtil.java
@@ -66,11 +66,19 @@ public class RegisterUtil {
                     return builder
                             .title(ComponentHelper.translatable(name))
                             .icon(() -> new ItemStack(icon.get()))
+                            //#if MC_VERSION >= 11904
                             .displayItems((parameters, output) -> {
                                 for (RegistrySupplier<Item> item : items) {
                                     output.accept(item.get());
                                 }
                             })
+                            //#else
+                            //$$ .displayItems((enabledFeatures, output, hasPermissions) -> {
+                            //$$     for (RegistrySupplier<Item> item : items) {
+                            //$$         output.accept(item.get());
+                            //$$     }
+                            //$$ })
+                            //#endif
                             .build();
                 }
         );


### PR DESCRIPTION
### Motivation
- Resolve compilation errors caused by Minecraft API differences across 1.18.2→1.20.1 (missing `getX()/getY()` accessors, changed widget render entry points, `Button` constructor changes, registry and item-renderer API changes). 
- Make UI widgets and registry helpers conditionally compatible so the same source tree can preprocess to each target MC version without generating references to unavailable methods or signatures. 
- Avoid runtime/compile failures from mismatched render/narration/registry calls and platform-specific method signatures. 

### Description
- Normalize widget rendering/narration entry points and coordinate access for multiple MC versions by updating conditional branches in `BasicConfigScreen`, `ConfigWidget`, `ConfigRow`, `CompoundWidget`, `SliderWidget`, and `AbstractMultiLineEditBox` and introducing a small `renderLabel` helper for `TextLabel` to centralize coordinate handling. 
- Adjust slider implementation to use `updateWidgetNarration` and `getX()/getY()` for MC >= 1.19.3 while preserving older-field access in legacy branches. 
- Switch to `Button.builder(...)` usage for MC >= 1.19.3 in UI classes and mixins (`ObjBlockConfigScreen`, `ScreendoorCentralControlScreen`, `LiftCustomizationScreenMixin`, etc.) and keep legacy `new Button(...)` in older conditional branches. 
- Add creative-tab support across versions by adding `CREATIVE_MODE_TAB_KEY` and `createCreativeTabRegister` in `FangSuRegistries`, and update `RegisterUtil.addCreativeTab` to handle the differing `displayItems` lambda signatures. 
- Fix imports and conditional use of `BuiltInRegistries` in `ModNetwork` and make item-renderer `renderStatic` calls conditional to the MC version (`ItemDisplayContext` handling for 1.19.4/1.20+). 
- Remove `@Override` from `tick` in screendoor blocks where signature mismatches caused "method does not override" compile errors in some versions. 

### Testing
- Ran a conditional-preprocessor smoke-check script that generated processed sources and validated the generated code for MC versions `1.18.2`, `1.19.2`, `1.19.3`, `1.19.4`, and `1.20.1`, and all checks passed. 
- Attempted a local `gradle :common:compileJava -Pgame_version=1.20.1` run (with Java 21) to exercise a real compile, but the build configuration failed due to an external environment proxy blocking Forge toolJar resolution (`Unable to tunnel through proxy ... 403 Forbidden`), so a full compile could not be completed in this environment.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a2ac8740bc4832e8353fa0a30d50203)