### PR TITLE
Fix Minecraft 1.19 registry and renderer compatibility

### DIFF
--- a/common/src/main/java/com/fangsu/blockEntities/client/BaseBlockEntityRender.java
+++ b/common/src/main/java/com/fangsu/blockEntities/client/BaseBlockEntityRender.java
@@ -68,7 +68,7 @@ public class BaseBlockEntityRender<T extends BaseObjBlockEntity> implements Bloc
             //#if MC_VERSION >= 12000
             Minecraft.getInstance().getItemRenderer().renderStatic(BARRIER_ITEM_STACK.get(), ItemDisplayContext.GROUND, lightToUse, 0, matrices, multiBufferSource, world, 0);
             //#elseif MC_VERSION >= 11904
-            //$$ Minecraft.getInstance().getItemRenderer().renderStatic(BARRIER_ITEM_STACK.get(), ItemDisplayContext.GROUND, lightToUse, 0, matrices, multiBufferSource, 0);
+            //$$ Minecraft.getInstance().getItemRenderer().renderStatic(BARRIER_ITEM_STACK.get(), ItemDisplayContext.GROUND, lightToUse, 0, matrices, multiBufferSource, world, 0);
             //#else
             //$$ Minecraft.getInstance().getItemRenderer().renderStatic(BARRIER_ITEM_STACK.get(), net.minecraft.client.renderer.block.model.ItemTransforms.TransformType.GROUND, lightToUse, 0, matrices, multiBufferSource, 0);
             //#endif

--- a/common/src/main/java/com/fangsu/mappings/FangSuRegistries.java
+++ b/common/src/main/java/com/fangsu/mappings/FangSuRegistries.java
@@ -26,7 +26,11 @@ public class FangSuRegistries {
     public static final ResourceLocation ITEM_KEY = net.minecraft.core.registries.Registries.ITEM.location();
     public static final ResourceLocation BLOCK_ENTITY_TYPE_KEY = net.minecraft.core.registries.Registries.BLOCK_ENTITY_TYPE.location();
     public static final ResourceLocation MENU_KEY = net.minecraft.core.registries.Registries.MENU.location();
+    //#if MC_VERSION >= 12000
     public static final ResourceLocation CREATIVE_MODE_TAB_KEY = net.minecraft.core.registries.Registries.CREATIVE_MODE_TAB.location();
+    //#else
+    //$$public static final ResourceLocation CREATIVE_MODE_TAB_KEY = new ResourceLocation("minecraft:creative_mode_tab");
+    //#endif
     //#else
     //$$public static final ResourceLocation BLOCK_KEY = new ResourceLocation("minecraft:block");
     //$$public static final ResourceLocation ITEM_KEY = new ResourceLocation("minecraft:item");


### PR DESCRIPTION
### Motivation
- Build fails on 1.19.3/1.19.4 due to missing `Registries.CREATIVE_MODE_TAB` and method-signature mismatch for `ItemRenderer#renderStatic`, so provide conditional compatibility for those versions while keeping 1.20+ behavior.

### Description
- Make `CREATIVE_MODE_TAB_KEY` conditional: use `Registries.CREATIVE_MODE_TAB.location()` for `MC_VERSION >= 12000` and emit a literal `ResourceLocation("minecraft:creative_mode_tab")` for older 1.19.x preprocessor paths so 1.19.3/1.19.4 compilation can succeed under the conditional source generator (`common/src/main/java/com/fangsu/mappings/FangSuRegistries.java`).
- Fix the 1.19 renderer branch to pass the `Level` argument to `ItemRenderer#renderStatic` in the `MC_VERSION >= 11904` pseudo-uncommented branch to match that version's method signature (`common/src/main/java/com/fangsu/blockEntities/client/BaseBlockEntityRender.java`).

### Testing
- `./gradlew :common:compileJava` (default `minecraft_version` → 1.20.1) succeeded (BUILD SUCCESSFUL) when run with Java 21 (`JAVA_HOME` set to a Java 21 runtime).
- Attempts to compile for `-Pgame_version=1.19.3` and `-Pgame_version=1.19.4` were exercised but blocked by environment issues fetching Minecraft metadata from Mojang (HTTP 403 / download failed after retries), so those targets could not be fully validated in this environment.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a2c1e192bec832eaf60a446f2558e8e)